### PR TITLE
feat(sensors): generic NMEA GPS driver for UM980 and other RTK receivers

### DIFF
--- a/.github/workflows/sensors-docker.yml
+++ b/.github/workflows/sensors-docker.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, dev]
     paths:
       - 'sensors/gps/**'
+      - 'sensors/gps-nmea/**'
       - 'sensors/lidar-ldlidar/**'
       - 'sensors/lidar-rplidar/**'
       - 'sensors/lidar-stl27l/**'
@@ -33,11 +34,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [gps, lidar-ldlidar, lidar-rplidar, lidar-stl27l, mavros]
+        image: [gps, gps-nmea, lidar-ldlidar, lidar-rplidar, lidar-stl27l, mavros]
         arch: [linux/amd64, linux/arm64]
         include:
           - image: gps
             context: ./sensors/gps
+            target: ""
+          - image: gps-nmea
+            context: ./sensors/gps-nmea
             target: ""
           - image: lidar-ldlidar
             context: ./sensors/lidar-ldlidar
@@ -124,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [gps, lidar-ldlidar, lidar-rplidar, lidar-stl27l, mavros]
+        image: [gps, gps-nmea, lidar-ldlidar, lidar-rplidar, lidar-stl27l, mavros]
 
     permissions:
       contents: read

--- a/install/compose/docker-compose.gps-nmea.yml
+++ b/install/compose/docker-compose.gps-nmea.yml
@@ -1,0 +1,35 @@
+  # -------------------------------------------------------------------------
+  # GPS — generic NMEA RTK driver + str2str NTRIP client
+  # Use for receivers that stream NMEA over a serial port (Unicore UM980,
+  # ArduSimple, Septentrio, etc.). For u-blox ZED-F9P over USB-CDC use the
+  # ublox_dgnss image in docker-compose.gps.yml instead.
+  # Publishes /gps/fix (NavSatFix). All config read from mowgli_robot.yaml.
+  # -------------------------------------------------------------------------
+x-ros2-env: &ros2-env
+  ROS_DOMAIN_ID: ${ROS_DOMAIN_ID:-0}
+  RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
+  ROS_AUTOMATIC_DISCOVERY_RANGE: LOCALHOST
+  RCUTILS_COLORIZED_OUTPUT: "1"
+  RCUTILS_LOGGING_USE_STDOUT: "1"
+
+services:
+
+  gps:
+    container_name: mowgli-gps
+    image: ${GPS_IMAGE}
+    network_mode: host
+    ipc: host
+    privileged: true
+    environment:
+      <<: *ros2-env
+    volumes:
+      - /dev:/dev
+      - ./config/mowgli:/config:ro
+      - ./config/cyclonedds.xml:/cyclonedds.xml:ro
+
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-file: "3"
+        max-size: 5m

--- a/install/lib/compose.sh
+++ b/install/lib/compose.sh
@@ -28,7 +28,15 @@ build_compose_stack() {
   COMPOSE_FILES+=("compose/docker-compose.base.yml")
   COMPOSE_FILES+=("compose/docker-compose.gui.yml")
   COMPOSE_FILES+=("compose/docker-compose.mqtt.yml")
-  COMPOSE_FILES+=("compose/docker-compose.gps.yml")
+
+  case "${GPS_PROTOCOL:-UBX}" in
+    NMEA)
+      COMPOSE_FILES+=("compose/docker-compose.gps-nmea.yml")
+      ;;
+    UBX|*)
+      COMPOSE_FILES+=("compose/docker-compose.gps.yml")
+      ;;
+  esac
 
   # Foxglove bridge is controlled via the ENABLE_FOXGLOVE env var passed
   # to the ROS2 container (see docker-compose.base.yml).  No separate

--- a/install/lib/config.sh
+++ b/install/lib/config.sh
@@ -15,6 +15,7 @@ UDEV_RULES_FILE="/etc/udev/rules.d/50-mowgli.rules"
 
 MOWGLI_ROS2_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/mowgli-ros2:main"
 GPS_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/gps:main"
+GPS_NMEA_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/gps-nmea:main"
 LIDAR_LDLIDAR_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/lidar-ldlidar:main"
 LIDAR_RPLIDAR_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/lidar-rplidar:main"
 LIDAR_STL27L_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/lidar-stl27l:main"

--- a/install/lib/env.sh
+++ b/install/lib/env.sh
@@ -53,9 +53,14 @@ setup_env() {
   : "${TFLUNA_EDGE_UART_DEVICE:=/dev/ttyAMA2}"
   : "${TFLUNA_EDGE_BAUD:=115200}"
 
-  # Images — select LiDAR image based on type
+  # Images — select GPS image by protocol, LiDAR image by type
   : "${MOWGLI_ROS2_IMAGE:=${MOWGLI_ROS2_IMAGE_DEFAULT}}"
-  : "${GPS_IMAGE:=${GPS_IMAGE_DEFAULT}}"
+  if [[ -z "${GPS_IMAGE:-}" ]]; then
+    case "${GPS_PROTOCOL:-UBX}" in
+      NMEA) GPS_IMAGE="${GPS_NMEA_IMAGE_DEFAULT}" ;;
+      *)    GPS_IMAGE="${GPS_IMAGE_DEFAULT}" ;;
+    esac
+  fi
   : "${GUI_IMAGE:=${GUI_IMAGE_DEFAULT}}"
   : "${MAVROS_IMAGE:=${MAVROS_IMAGE_DEFAULT}}"
   if [[ -z "${LIDAR_IMAGE:-}" ]]; then

--- a/sensors/README.md
+++ b/sensors/README.md
@@ -4,28 +4,39 @@ Dockerized ROS2 drivers for each supported sensor. Each subdirectory contains a 
 
 ## Supported Sensors
 
-| Sensor | Type | Directory | ROS2 Topic | Protocol |
-|--------|------|-----------|------------|----------|
-| u-blox ZED-F9P | RTK GPS | [`gps/`](gps/) | `/ublox_gps_node/fix` (NavSatFix) | USB-CDC |
-| LDRobot LD19 | 2D LiDAR | [`lidar/`](lidar/) | `/scan` (LaserScan) | UART 230400 |
+| Sensor | Type | Directory | ROS2 Topic | Transport |
+|--------|------|-----------|------------|-----------|
+| u-blox ZED-F9P | RTK GPS (UBX) | [`gps/`](gps/) | `/gps/fix` (NavSatFix) | USB-CDC (libusb) |
+| Unicore UM980 / generic NMEA | RTK GPS (NMEA) | [`gps-nmea/`](gps-nmea/) | `/gps/fix` (NavSatFix) | Serial (`/dev/gps`) |
+| LDRobot LD19 / LD06 / LD14 | 2D LiDAR | [`lidar-ldlidar/`](lidar-ldlidar/) | `/scan` (LaserScan) | UART 230400 |
+| Slamtec RPLiDAR A-series | 2D LiDAR | [`lidar-rplidar/`](lidar-rplidar/) | `/scan` (LaserScan) | USB / UART |
+| LDRobot STL27L | 2D LiDAR (experimental) | [`lidar-stl27l/`](lidar-stl27l/) | `/scan` (LaserScan) | UART 230400 |
+| MAVLink autopilot | MAVROS bridge | [`mavros/`](mavros/) | MAVROS topics | Serial / UDP |
+
+## Choosing a GPS image
+
+- `gps/` — for u-blox ZED-F9P over USB-CDC. Uses `ublox_dgnss` (libusb) and a bundled NTRIP client; exposes the full UBX topic tree including RTK Fixed/Float status.
+- `gps-nmea/` — for any RTK receiver that streams NMEA over a serial port (Unicore UM980/UM982, ArduSimple simpleRTK2B, Septentrio, etc.). Uses `nmea_navsat_driver` plus `str2str` (rtklib) for NTRIP RTCM3 injection back to the serial device.
+
+Both images publish `/gps/fix` (`sensor_msgs/NavSatFix`) so downstream consumers (FusionCore, `navsat_to_absolute_pose`) don't care which one is running.
 
 ## Adding a New Sensor
 
-To add support for a different GPS or LiDAR model:
-
-1. Create a new directory (e.g., `sensors/lidar-rplidar/`)
-2. Add a `Dockerfile` that builds the ROS2 driver and publishes the expected topic
-3. Add a `ros2_entrypoint.sh` for environment setup
-4. Update `docker/docker-compose.yaml` to point the service's `build.context` at your new directory
-5. Ensure the driver publishes on the standard topic (`/scan` for LiDAR, `/ublox_gps_node/fix` or `/gps/fix` for GPS)
+1. Create a new directory (e.g., `sensors/gps-foo/`).
+2. Add a `Dockerfile` that builds the ROS2 driver and publishes the expected topic.
+3. Add a `ros2_entrypoint.sh` for environment setup.
+4. Add a matching `install/compose/docker-compose.<name>.yml` snippet.
+5. Wire it into `install/lib/compose.sh::build_compose_stack` (and `install/lib/env.sh` for image defaults).
+6. Add the new image to the matrix in `.github/workflows/sensors-docker.yml`.
 
 ## Building
 
-Images are built automatically by the CI workflow (`.github/workflows/docker.yml`) for `linux/amd64` and `linux/arm64`.
+Images are built automatically by the CI workflow ([`.github/workflows/sensors-docker.yml`](../.github/workflows/sensors-docker.yml)) for `linux/amd64` and `linux/arm64`.
 
 To build locally:
 
 ```bash
-docker build -t mowgli-gps sensors/gps/
-docker build -t mowgli-lidar --target runtime sensors/lidar/
+docker build -t mowgli-gps         sensors/gps/
+docker build -t mowgli-gps-nmea    sensors/gps-nmea/
+docker build -t mowgli-lidar-ld19  --target runtime sensors/lidar-ldlidar/
 ```

--- a/sensors/gps-nmea/Dockerfile
+++ b/sensors/gps-nmea/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1.7
+# =============================================================================
+# Generic NMEA GPS driver + NTRIP client (str2str) for ROS2 Kilted.
+#
+# Use this image when sensors/gps/ (ublox_dgnss / ZED-F9P over USB-CDC) does
+# not apply — i.e. for any RTK receiver that streams NMEA over a serial port:
+#
+#   * Unicore UM980 / UM982            (USB-CDC, NMEA at 115200)
+#   * ArduSimple simpleRTK2B variants   (USB-CDC, NMEA configurable)
+#   * Septentrio Mosaic                 (USB-CDC, NMEA configurable)
+#   * u-blox ZED-F9P configured to NMEA-only (rare; ublox_dgnss is preferred)
+#
+# Components:
+#   1. nmea_serial_bridge.py     reads /dev/gps NMEA → publishes nmea_msgs/Sentence
+#                                on /nmea_sentence (RELIABLE QoS)
+#   2. nmea_navsat_driver        nmea_topic_driver: /nmea_sentence → /gps/fix
+#                                (sensor_msgs/NavSatFix), /gps/vel, /gps/time_reference
+#   3. str2str (rtklib)          NTRIP client: pulls RTCM3 from caster, writes
+#                                directly to the serial device opened by (1)
+#                                — Linux allows multiple opens of the same
+#                                CDC node, so read (Python) and write (str2str)
+#                                cohabit fine.
+#
+# Config is read from /config/mowgli_robot.yaml (bind-mounted from the
+# install dir) — same convention as sensors/gps/.
+# =============================================================================
+
+FROM ros:kilted-ros-base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+      /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      ros-kilted-nmea-navsat-driver \
+      ros-kilted-rmw-cyclonedds-cpp \
+      python3-serial \
+      rtklib \
+      inotify-tools
+
+COPY ros2_entrypoint.sh /ros2_entrypoint.sh
+COPY start_gps_nmea.sh /start_gps_nmea.sh
+COPY nmea_serial_bridge.py /nmea_serial_bridge.py
+RUN chmod +x /ros2_entrypoint.sh /start_gps_nmea.sh /nmea_serial_bridge.py
+
+ENTRYPOINT ["/ros2_entrypoint.sh"]
+CMD ["/start_gps_nmea.sh"]

--- a/sensors/gps-nmea/nmea_serial_bridge.py
+++ b/sensors/gps-nmea/nmea_serial_bridge.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# =============================================================================
+# NMEA serial bridge: reads NMEA sentences from /dev/gps and republishes them
+# as nmea_msgs/Sentence on /nmea_sentence for downstream consumers
+# (nmea_navsat_driver's nmea_topic_driver).
+#
+# Why a separate bridge instead of nmea_navsat_driver's built-in nmea_serial_driver?
+# - We want the raw sentences on a topic (debugging, logging, future consumers).
+# - We control QoS explicitly (RELIABLE) — Cyclone DDS rejects RELIABLE
+#   subscribers paired with BEST_EFFORT publishers, and FusionCore /
+#   navsat_to_absolute_pose subscribe RELIABLE. See sensors/gps/ublox_dgnss.yaml
+#   for the same fix on the ublox side.
+# - We add automatic reconnect on serial errors (USB hot-unplug, kernel
+#   re-enumeration after str2str write bursts).
+# =============================================================================
+
+import threading
+import time
+
+import rclpy
+import serial
+from nmea_msgs.msg import Sentence
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+
+RECONNECT_DELAY_S = 1.0
+
+
+class NmeaSerialBridge(Node):
+    def __init__(self) -> None:
+        super().__init__("nmea_serial_bridge")
+        self.declare_parameter("port", "/dev/gps")
+        self.declare_parameter("baud", 115200)
+        self.declare_parameter("frame_id", "gps_link")
+
+        self._port = self.get_parameter("port").value
+        self._baud = int(self.get_parameter("baud").value)
+        self._frame_id = self.get_parameter("frame_id").value
+
+        qos = QoSProfile(
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            durability=QoSDurabilityPolicy.VOLATILE,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            depth=10,
+        )
+        self._pub = self.create_publisher(Sentence, "nmea_sentence", qos)
+
+        self._stop = threading.Event()
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _read_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                with serial.Serial(self._port, self._baud, timeout=1.0) as ser:
+                    self.get_logger().info(
+                        f"opened {self._port} @ {self._baud} baud, publishing /nmea_sentence"
+                    )
+                    while not self._stop.is_set():
+                        raw = ser.readline()
+                        if not raw:
+                            continue
+                        line = raw.decode("ascii", errors="replace").strip()
+                        if not line.startswith("$"):
+                            continue
+                        msg = Sentence()
+                        msg.header.stamp = self.get_clock().now().to_msg()
+                        msg.header.frame_id = self._frame_id
+                        msg.sentence = line
+                        self._pub.publish(msg)
+            except serial.SerialException as e:
+                self.get_logger().warning(
+                    f"serial error on {self._port}: {e}; reconnecting in {RECONNECT_DELAY_S}s"
+                )
+                time.sleep(RECONNECT_DELAY_S)
+            except OSError as e:
+                self.get_logger().warning(
+                    f"OS error opening {self._port}: {e}; reconnecting in {RECONNECT_DELAY_S}s"
+                )
+                time.sleep(RECONNECT_DELAY_S)
+
+    def destroy_node(self) -> bool:
+        self._stop.set()
+        self._reader.join(timeout=2.0)
+        return super().destroy_node()
+
+
+def main() -> None:
+    rclpy.init()
+    node = NmeaSerialBridge()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/sensors/gps-nmea/ros2_entrypoint.sh
+++ b/sensors/gps-nmea/ros2_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+set +u
+source /opt/ros/kilted/setup.bash
+set -u
+exec "$@"

--- a/sensors/gps-nmea/start_gps_nmea.sh
+++ b/sensors/gps-nmea/start_gps_nmea.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# =============================================================================
+# NMEA GPS startup. Reads config from /config/mowgli_robot.yaml.
+#
+# Launches:
+#   1. nmea_serial_bridge.py    /dev/gps → /nmea_sentence (RELIABLE)
+#   2. nmea_topic_driver        /nmea_sentence → /gps/fix (NavSatFix)
+#   3. str2str (NTRIP)          NTRIP caster → RTCM3 → /dev/gps (write side)
+#   + inotify watcher reloads str2str when ntrip_* keys in the YAML change.
+# =============================================================================
+set -euo pipefail
+
+CONFIG="/config/mowgli_robot.yaml"
+[ -f "$CONFIG" ] || { echo "[gps-nmea] $CONFIG missing — bind-mount install/config/mowgli to /config"; exit 1; }
+
+parse_yaml() {
+  grep -E "^\s+${1}:" "$CONFIG" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '"' | tr -d "'"
+}
+
+GPS_PORT=$(parse_yaml gps_port)
+GPS_BAUD=$(parse_yaml gps_baudrate)
+GPS_FRAME=$(parse_yaml gps_frame_id)
+NTRIP_ENABLED=$(parse_yaml ntrip_enabled)
+NTRIP_HOST=$(parse_yaml ntrip_host)
+NTRIP_PORT=$(parse_yaml ntrip_port)
+NTRIP_USER=$(parse_yaml ntrip_user)
+NTRIP_PASS=$(parse_yaml ntrip_password)
+NTRIP_MOUNT=$(parse_yaml ntrip_mountpoint)
+
+GPS_PORT="${GPS_PORT:-/dev/gps}"
+GPS_BAUD="${GPS_BAUD:-115200}"
+GPS_FRAME="${GPS_FRAME:-gps_link}"
+NTRIP_ENABLED="${NTRIP_ENABLED:-false}"
+NTRIP_PORT="${NTRIP_PORT:-2101}"
+
+echo "[gps-nmea] port=$GPS_PORT baud=$GPS_BAUD frame=$GPS_FRAME ntrip=$NTRIP_ENABLED"
+
+set +u; source /opt/ros/kilted/setup.bash; set -u
+
+# 1. Raw NMEA reader → /nmea_sentence (RELIABLE inside the script).
+python3 /nmea_serial_bridge.py --ros-args \
+  -p port:="${GPS_PORT}" \
+  -p baud:="${GPS_BAUD}" \
+  -p frame_id:="${GPS_FRAME}" &
+BRIDGE_PID=$!
+
+# 2. nmea_navsat_driver topic mode: /nmea_sentence → /gps/fix.
+#    Trust the driver's default publisher QoS (RELIABLE in current upstream).
+#    If FusionCore stops receiving fixes after upstream changes, switch to a
+#    bespoke NavSatFix publisher inside nmea_serial_bridge.py.
+ros2 run nmea_navsat_driver nmea_topic_driver --ros-args \
+  -p frame_id:="${GPS_FRAME}" \
+  -p time_ref_source:=gps \
+  -p useRMC:=false \
+  -p use_GNSS_time:=false \
+  -r /fix:=/gps/fix \
+  -r /vel:=/gps/vel \
+  -r /time_reference:=/gps/time_reference &
+DRIVER_PID=$!
+
+# 3. NTRIP via str2str — pulls RTCM3 from the caster, writes it to the GPS
+#    serial device. Multi-opener safe on Linux CDC.
+STR2STR_PID=0
+start_str2str() {
+  [ "$NTRIP_ENABLED" = "true" ] || return
+  [ -n "${NTRIP_HOST:-}" ] && [ -n "${NTRIP_MOUNT:-}" ] || {
+    echo "[gps-nmea] NTRIP enabled but host/mountpoint missing"; return; }
+  echo "[gps-nmea] NTRIP -> ${NTRIP_HOST}:${NTRIP_PORT}/${NTRIP_MOUNT} -> ${GPS_PORT}"
+  str2str \
+    -in "ntrip://${NTRIP_USER}:${NTRIP_PASS}@${NTRIP_HOST}:${NTRIP_PORT}/${NTRIP_MOUNT}" \
+    -out "file://${GPS_PORT}" &
+  STR2STR_PID=$!
+}
+
+stop_str2str() {
+  [ "${STR2STR_PID}" -gt 0 ] && kill -0 "${STR2STR_PID}" 2>/dev/null || return 0
+  kill -TERM "${STR2STR_PID}" 2>/dev/null || true
+  for _ in 1 2 3 4 5; do kill -0 "${STR2STR_PID}" 2>/dev/null || break; sleep 0.5; done
+  kill -KILL "${STR2STR_PID}" 2>/dev/null || true
+  wait "${STR2STR_PID}" 2>/dev/null || true
+  STR2STR_PID=0
+}
+
+cleanup() {
+  stop_str2str
+  kill "${DRIVER_PID}" "${BRIDGE_PID}" 2>/dev/null || true
+  exit 0
+}
+trap cleanup TERM INT
+
+# Give the bridge a beat to open the serial device before NTRIP starts writing.
+sleep 3
+start_str2str
+
+# Hot-reload NTRIP on config changes (so users editing the YAML via the GUI
+# don't need to restart the container).
+if [ "$NTRIP_ENABLED" = "true" ] && command -v inotifywait >/dev/null 2>&1; then
+  (
+    while true; do
+      inotifywait -q -e close_write,move_self,delete_self "$CONFIG" || true
+      echo "[gps-nmea] config changed — reloading NTRIP"
+      NTRIP_HOST=$(parse_yaml ntrip_host)
+      NTRIP_PORT=$(parse_yaml ntrip_port)
+      NTRIP_USER=$(parse_yaml ntrip_user)
+      NTRIP_PASS=$(parse_yaml ntrip_password)
+      NTRIP_MOUNT=$(parse_yaml ntrip_mountpoint)
+      NTRIP_ENABLED=$(parse_yaml ntrip_enabled)
+      stop_str2str
+      sleep 0.5
+      start_str2str
+    done
+  ) &
+fi
+
+wait -n || true
+cleanup


### PR DESCRIPTION
## Summary
- Adds `sensors/gps-nmea/` — a second GPS image so the project supports any RTK receiver that streams NMEA over a serial port (Unicore UM980/UM982, ArduSimple, Septentrio, etc.), not only u-blox ZED-F9P over USB-CDC via `sensors/gps/`.
- Wires the chain end-to-end: `install/lib/compose.sh` selects the new compose file when `GPS_PROTOCOL=NMEA`, `install/lib/env.sh` picks the new image, `install/lib/config.sh` declares its default GHCR ref, `.github/workflows/sensors-docker.yml` builds it for `linux/amd64` and `linux/arm64`.
- The installer already accepted `--gps=nmea-*` and offered NMEA in the interactive flow — those paths were dead-ends without this image.

## Pipeline
1. `nmea_serial_bridge.py` — reads `/dev/gps` NMEA via `pyserial`, republishes raw `nmea_msgs/Sentence` on `/nmea_sentence`. **RELIABLE QoS** (Cyclone DDS rejects RELIABLE-sub ↔ BEST_EFFORT-pub; FusionCore subscribes RELIABLE — see `sensors/gps/ublox_dgnss.yaml` for the same fix on the ublox side). Auto-reconnect on `SerialException` (USB hot-unplug, kernel re-enumeration).
2. `nmea_navsat_driver` (`nmea_topic_driver`) — `/nmea_sentence` → `/gps/fix` (`sensor_msgs/NavSatFix`), same topic name as the ublox image so FusionCore / `navsat_to_absolute_pose` don't care which GPS image is running.
3. `str2str` (rtklib) — NTRIP client, pulls RTCM3 from the caster, writes directly to `/dev/gps`. Linux allows multiple opens of the same CDC node, so read (Python) and write (str2str) cohabit fine.
4. `inotifywait` watcher — hot-reloads the `str2str` process when `ntrip_*` keys in `mowgli_robot.yaml` change (so GUI edits don't need a container restart).

## Why two GPS images, not one?
- `sensors/gps/` (ublox_dgnss): full UBX topic tree, libusb (no `/dev` path), bundled NTRIP, exposes `/ubx_nav_status.carr_soln` for RTK Fixed/Float classification. Needed for u-blox-specific FusionCore tuning.
- `sensors/gps-nmea/`: lightweight, apt-only (no source build), works with any NMEA-streaming receiver. The trade-off is no UBX-level diagnostics — fix quality comes from the NMEA `GGA` quality field.

Both publish `/gps/fix`. The choice is made once at install time via `GPS_PROTOCOL`.

## Test plan
- [ ] `docker build -t mowgli-gps-nmea:test sensors/gps-nmea/` succeeds locally on amd64.
- [ ] CI builds the image for amd64 + arm64 (will fire on push because of the new `paths: sensors/gps-nmea/**`).
- [ ] Run on Pi5 with UM980 connected: confirm `/gps/fix` is published with `status: 1` (no RTK) before NTRIP, then `status: 2` after RTCM corrections start flowing (`str2str` log shows `[CR]` activity).
- [ ] Confirm FusionCore (`/fusion/odom`) receives the fixes — i.e. RELIABLE QoS handshake works.
- [ ] Hot-unplug + replug the GPS USB cable; bridge auto-reconnects within ~1 s.
- [ ] Re-run the installer with `--gps=nmea-usb`; check generated `.env` has `GPS_IMAGE=…/gps-nmea:main` and `docker-compose.yaml` includes the new compose snippet.

## Out of scope (follow-ups)
- UM980 dual-antenna heading — single-antenna users only here; hardware heading needs a separate PR with FusionCore plumbing.
- udev rule for UM980 USB IDs — needs `lsusb` output from real hardware to fix `idVendor`/`idProduct`. Daniel can append to `install/lib/udev.sh` and the existing `udev-50-mowgli.rules` once known.