### PR TITLE
chore(install): repoint default image refs to this fork

### DIFF
--- a/install/lib/config.sh
+++ b/install/lib/config.sh
@@ -13,14 +13,14 @@ DOCKER_SUBDIR="install"
 INSTALL_DIR="${REPO_DIR}/${DOCKER_SUBDIR}"
 UDEV_RULES_FILE="/etc/udev/rules.d/50-mowgli.rules"
 
-MOWGLI_ROS2_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/mowgli-ros2:main"
-GPS_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/gps:main"
-GPS_NMEA_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/gps-nmea:main"
-LIDAR_LDLIDAR_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/lidar-ldlidar:main"
-LIDAR_RPLIDAR_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/lidar-rplidar:main"
-LIDAR_STL27L_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/lidar-stl27l:main"
-MAVROS_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/mavros:main"
-GUI_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/mowglinext-gui:main"
+MOWGLI_ROS2_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mowgli-ros2:main"
+GPS_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/gps:main"
+GPS_NMEA_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/gps-nmea:main"
+LIDAR_LDLIDAR_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-ldlidar:main"
+LIDAR_RPLIDAR_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-rplidar:main"
+LIDAR_STL27L_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-stl27l:main"
+MAVROS_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mavros:main"
+GUI_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mowglinext-gui:main"
 
 CHECK_ONLY=false
 CLI_PRESET=false


### PR DESCRIPTION
## Summary
Switches all 7 \`*_IMAGE_DEFAULT\` constants in \`install/lib/config.sh\` from \`ghcr.io/cedbossneo/mowglinext/*\` to \`ghcr.io/danyial/mowglinext/*\`, so a fresh installer run on this fork actually pulls the images the fork's CI produces.

Without this, \`docker compose pull\` reaches for upstream images that may diverge from the fork's source tree (or simply don't exist for new images like \`gps-nmea\`).

## Required follow-up before this works end-to-end
The fork's CI hasn't built \`mowgli-ros2\` or \`mowglinext-gui\` yet — both workflows are path-gated on \`ros2/**\` and \`gui/**\` and haven't fired on this fork. Trigger them once after merge:

\`\`\`bash
gh workflow run ros2-docker.yml --ref dev
gh workflow run gui-docker.yml  --ref dev
\`\`\`

After those finish (~30+ min for \`mowgli-ros2\` due to colcon build), the new defaults pull cleanly.

## Out of scope
\`docker/.env\` and \`docker/.env.example\` still point at unrelated legacy upstream repos (\`cedbossneo/mowgli-docker\`, \`cedbossneo/openmower-gui\`) — different image-name structure, would need restructuring not just renaming. Separate cleanup.

\`gui/go.mod\`, \`gui/main.go\` and friends keep \`github.com/cedbossneo/mowglinext/...\` as their Go module path — that's an identifier, not a build target. Touching it would require renaming all imports across ~20 Go files for zero functional gain.

Documentation URLs (\`README.md\`, \`CLAUDE.md\`, \`SECURITY.md\`, \`wiki/**\`) still link to upstream — separate, low-priority cleanup PR.

## Test plan
- [ ] After merge, trigger \`ros2-docker.yml\` and \`gui-docker.yml\` manually.
- [ ] On Pi: \`./mowglinext.sh --gps=nmea-usb --lidar=ldlidar-uart\` runs end-to-end without "image not found" errors.