### PR TITLE
chore(ci): drop ublox gps image from this fork's CI matrix

### DIFF
--- a/.github/workflows/sensors-docker.yml
+++ b/.github/workflows/sensors-docker.yml
@@ -4,12 +4,15 @@ on:
   push:
     branches: [main, dev]
     paths:
-      - 'sensors/gps/**'
+      # 'sensors/gps/**' (ublox_dgnss) is built upstream only — push-by-digest
+      # to this fork's GHCR namespace fails consistently for the multi-stage
+      # ublox build. NMEA receivers (UM980, etc.) are the supported path here.
       - 'sensors/gps-nmea/**'
       - 'sensors/lidar-ldlidar/**'
       - 'sensors/lidar-rplidar/**'
       - 'sensors/lidar-stl27l/**'
       - 'sensors/mavros/**'
+      - '.github/workflows/sensors-docker.yml'
   workflow_dispatch:
     inputs:
       no-cache:
@@ -34,12 +37,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [gps, gps-nmea, lidar-ldlidar, lidar-rplidar, lidar-stl27l, mavros]
+        image: [gps-nmea, lidar-ldlidar, lidar-rplidar, lidar-stl27l, mavros]
         arch: [linux/amd64, linux/arm64]
         include:
-          - image: gps
-            context: ./sensors/gps
-            target: ""
           - image: gps-nmea
             context: ./sensors/gps-nmea
             target: ""
@@ -128,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [gps, gps-nmea, lidar-ldlidar, lidar-rplidar, lidar-stl27l, mavros]
+        image: [gps-nmea, lidar-ldlidar, lidar-rplidar, lidar-stl27l, mavros]
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
The \`Merge manifest (gps)\` job consistently fails on this fork's GHCR namespace — even with no-cache full rebuilds. The build step reports success and exports a digest, but the merge step can never resolve that digest in GHCR. Suspected cause: race between cache-to push and digest push for the multi-stage ublox build (\`sensors/gps/\` compiles ublox_dgnss from source — much larger than the other sensor images), combined with attestation-index churn.

This fork uses NMEA receivers (UM980, etc.), so the ublox image is dead weight. Drop it from the build + merge matrix to keep CI green.

## What's kept
- \`sensors/gps/\` source untouched — anyone can still \`docker build sensors/gps/\` locally.
- Upstream \`cedbossneo/mowglinext\` continues to publish \`ghcr.io/cedbossneo/mowglinext/gps:main\`. If a fork user picks UBX, they can override \`GPS_IMAGE\` in \`.env\` to point upstream.
- Re-enabling later is a one-line revert in both matrix lists.

## Other change
Adds \`.github/workflows/sensors-docker.yml\` itself to the \`paths\` trigger, matching the convention in \`gui-docker.yml\` and \`ros2-docker.yml\` (so future edits to this workflow re-run the build).

## Test plan
- [ ] After merge, the next sensors-docker run shows 5 build matrix entries instead of 6 — all green.