### PR TITLE
chore(install): default GPS to NMEA, point UBX image at upstream

### DIFF
--- a/install/lib/compose.sh
+++ b/install/lib/compose.sh
@@ -29,12 +29,12 @@ build_compose_stack() {
   COMPOSE_FILES+=("compose/docker-compose.gui.yml")
   COMPOSE_FILES+=("compose/docker-compose.mqtt.yml")
 
-  case "${GPS_PROTOCOL:-UBX}" in
-    NMEA)
-      COMPOSE_FILES+=("compose/docker-compose.gps-nmea.yml")
-      ;;
-    UBX|*)
+  case "${GPS_PROTOCOL:-NMEA}" in
+    UBX)
       COMPOSE_FILES+=("compose/docker-compose.gps.yml")
+      ;;
+    NMEA|*)
+      COMPOSE_FILES+=("compose/docker-compose.gps-nmea.yml")
       ;;
   esac
 

--- a/install/lib/config.sh
+++ b/install/lib/config.sh
@@ -14,7 +14,11 @@ INSTALL_DIR="${REPO_DIR}/${DOCKER_SUBDIR}"
 UDEV_RULES_FILE="/etc/udev/rules.d/50-mowgli.rules"
 
 MOWGLI_ROS2_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mowgli-ros2:main"
-GPS_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/gps:main"
+# UBX (ublox_dgnss) image is NOT built by this fork's CI — see
+# .github/workflows/sensors-docker.yml. The fork primarily targets NMEA
+# receivers (UM980, etc.). For UBX users we point at the upstream image,
+# which tracks the same sensors/gps/ source.
+GPS_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/gps:main"
 GPS_NMEA_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/gps-nmea:main"
 LIDAR_LDLIDAR_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-ldlidar:main"
 LIDAR_RPLIDAR_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-rplidar:main"

--- a/install/lib/env.sh
+++ b/install/lib/env.sh
@@ -21,12 +21,13 @@ setup_env() {
   : "${MOWER_IP:=10.0.0.161}"
   : "${DISABLE_BLUETOOTH:=true}"
 
-  # GPS
+  # GPS — fork defaults to NMEA (UM980 etc.). UBX users override at install
+  # time via --gps=ubx-* (the ubx image comes from upstream — see config.sh).
   : "${GPS_CONNECTION:=uart}"
-  : "${GPS_PROTOCOL:=UBX}"
+  : "${GPS_PROTOCOL:=NMEA}"
   : "${GPS_PORT:=/dev/gps}"
   : "${GPS_UART_DEVICE:=/dev/ttyAMA4}"
-  : "${GPS_BAUD:=460800}"
+  : "${GPS_BAUD:=115200}"
 
   : "${GPS_DEBUG_ENABLED:=false}"
   : "${GPS_DEBUG_PORT:=/dev/gps_debug}"

--- a/install/lib/gps.sh
+++ b/install/lib/gps.sh
@@ -26,12 +26,13 @@ configure_gps() {
       GPS_DEBUG_UART_DEVICE="$REPLY"
     fi
   else
-    # Defaults based on PCB / GUI-ready
-    : "${GPS_PROTOCOL:=UBX}"
+    # Defaults: NMEA primary on this fork (UM980 etc.); UBX still selectable
+    # but pulls the ublox image from upstream cedbossneo/mowglinext.
+    : "${GPS_PROTOCOL:=NMEA}"
     : "${GPS_CONNECTION:=uart}"
     : "${GPS_PORT:=/dev/gps}"
     : "${GPS_UART_DEVICE:=/dev/ttyAMA4}"
-    : "${GPS_BAUD:=460800}"
+    : "${GPS_BAUD:=115200}"
 
     # Debug only on miniUART
     : "${GPS_DEBUG_ENABLED:=false}"
@@ -64,19 +65,22 @@ configure_gps() {
 
     echo ""
     echo "$MSG_GPS_PROTOCOL"
-    echo "  1) UBX"
-    echo "  2) NMEA"
+    echo "  1) NMEA   (UM980, ArduSimple, Septentrio, generic NMEA RTK) [default]"
+    echo "  2) UBX    (u-blox ZED-F9P — image pulled from upstream)"
     prompt "$MSG_CHOICE" "1"
     local proto_choice="$REPLY"
 
     case "$proto_choice" in
       1)
-        GPS_PROTOCOL="UBX"
-        GPS_BAUD="460800"
-        ;;
-      2)
         GPS_PROTOCOL="NMEA"
         GPS_BAUD="115200"
+        ;;
+      2)
+        GPS_PROTOCOL="UBX"
+        GPS_BAUD="460800"
+        warn "UBX selected — pulling ublox image from upstream (cedbossneo/mowglinext)."
+        warn "  This fork's CI does not build the ublox image. Override GPS_IMAGE in"
+        warn "  .env if you want a different source."
         ;;
       *)
         error "$MSG_GPS_INVALID_PROTOCOL"

--- a/sensors/README.md
+++ b/sensors/README.md
@@ -20,6 +20,12 @@ Dockerized ROS2 drivers for each supported sensor. Each subdirectory contains a 
 
 Both images publish `/gps/fix` (`sensor_msgs/NavSatFix`) so downstream consumers (FusionCore, `navsat_to_absolute_pose`) don't care which one is running.
 
+> **Fork note:** this fork's CI builds only `gps-nmea`. The `gps` (ublox) image
+> is pulled from upstream `cedbossneo/mowglinext` — its source under `sensors/gps/`
+> stays in sync, but the image push to this fork's GHCR is currently disabled
+> (push-by-digest race for the multi-stage ublox build). To re-enable, add
+> `gps` back to both `matrix.image` lists in `.github/workflows/sensors-docker.yml`.
+
 ## Adding a New Sensor
 
 1. Create a new directory (e.g., `sensors/gps-foo/`).


### PR DESCRIPTION
## Summary
Follow-up to PR #4 (drops ublox \`gps\` from this fork's sensors-docker matrix). Realigns the installer so its defaults and prompts match what the fork can actually ship.

- Default \`GPS_PROTOCOL\` flips **UBX → NMEA** in \`env.sh\`, \`gps.sh\`, \`compose.sh\`. Default baud follows (\`115200\` instead of \`460800\`).
- Interactive prompt now lists **NMEA first** (default), UBX second with a \`warn()\` that the ublox image comes from upstream.
- \`GPS_IMAGE_DEFAULT\` repointed at \`ghcr.io/cedbossneo/mowglinext/gps:main\` — UBX still works, image pulled from upstream which tracks the same \`sensors/gps/\` source.
- \`sensors/README.md\` gets the matching "fork note".

## Why defensive (not aggressive)
\`sensors/gps/\` source stays — the build problem is GHCR push-by-digest behavior, not the code. Anyone can \`docker build sensors/gps/\` locally, and ZED-F9P users on this fork get a working install via the upstream image. If the GHCR push issue is solved later, the only edits needed to re-enable here are:

1. Add \`gps\` back to both \`matrix.image\` lists in \`sensors-docker.yml\`.
2. Repoint \`GPS_IMAGE_DEFAULT\` back to \`ghcr.io/danyial/mowglinext/gps:main\`.

## CLI presets
\`--gps=nmea-usb\` / \`--gps=ubx-uart\` etc. are unchanged — they already worked. Only the *interactive* default + image origin shifted.

## Test plan
- [ ] On Pi: \`./mowglinext.sh\` (interactive, no flags) → defaults to NMEA, no UBX warning shown.
- [ ] \`./mowglinext.sh\` and pick option 2 (UBX) → warning printed, \`.env\` has \`GPS_IMAGE=ghcr.io/cedbossneo/mowglinext/gps:main\`.
- [ ] \`./mowglinext.sh --gps=nmea-usb\` → unchanged behavior.