### PR TITLE
fix(install): IMAGE_TAG follows active branch instead of hardcoded :main

### DIFF
--- a/install/lib/config.sh
+++ b/install/lib/config.sh
@@ -27,18 +27,45 @@ DOCKER_SUBDIR="install"
 INSTALL_DIR="${REPO_DIR}/${DOCKER_SUBDIR}"
 UDEV_RULES_FILE="/etc/udev/rules.d/50-mowgli.rules"
 
-MOWGLI_ROS2_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mowgli-ros2:main"
-# UBX (ublox_dgnss) image is NOT built by this fork's CI — see
-# .github/workflows/sensors-docker.yml. The fork primarily targets NMEA
-# receivers (UM980, etc.). For UBX users we point at the upstream image,
-# which tracks the same sensors/gps/ source.
-GPS_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/gps:main"
-GPS_NMEA_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/gps-nmea:main"
-LIDAR_LDLIDAR_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-ldlidar:main"
-LIDAR_RPLIDAR_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-rplidar:main"
-LIDAR_STL27L_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-stl27l:main"
-MAVROS_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mavros:main"
-GUI_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mowglinext-gui:main"
+# Track whether IMAGE_TAG came from an explicit source (env var or
+# --image-tag= flag). If yes, branch changes won't override it.
+IMAGE_TAG_EXPLICIT=false
+[ -n "${IMAGE_TAG:-}" ] && IMAGE_TAG_EXPLICIT=true
+
+# Image tag + defaults are derived after parse_args() so that --branch=
+# can rewire the tag. Call derive_image_defaults() again if you mutate
+# REPO_BRANCH or IMAGE_TAG after sourcing this file.
+#
+# CI only publishes images for `main` and `dev` (see
+# .github/workflows/sensors-docker.yml et al.) — anything else falls back
+# to `:main` so users on feature branches still get a working pull.
+# Override with IMAGE_TAG=foo env or --image-tag=foo if you've published
+# a custom tag (e.g. a release tag, a PR-build tag).
+derive_image_defaults() {
+  if [ "$IMAGE_TAG_EXPLICIT" != "true" ]; then
+    case "$REPO_BRANCH" in
+      main|dev) IMAGE_TAG="$REPO_BRANCH" ;;
+      *)        IMAGE_TAG="main" ;;
+    esac
+  fi
+
+  MOWGLI_ROS2_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mowgli-ros2:${IMAGE_TAG}"
+  # UBX (ublox_dgnss) image is NOT built by this fork's CI — see
+  # .github/workflows/sensors-docker.yml. The fork primarily targets NMEA
+  # receivers (UM980, etc.). For UBX users we point at the upstream image,
+  # which tracks the same sensors/gps/ source. This default stays on :main
+  # regardless of IMAGE_TAG because cedbossneo only publishes :main.
+  GPS_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/gps:main"
+  GPS_NMEA_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/gps-nmea:${IMAGE_TAG}"
+  LIDAR_LDLIDAR_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-ldlidar:${IMAGE_TAG}"
+  LIDAR_RPLIDAR_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-rplidar:${IMAGE_TAG}"
+  LIDAR_STL27L_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/lidar-stl27l:${IMAGE_TAG}"
+  MAVROS_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mavros:${IMAGE_TAG}"
+  GUI_IMAGE_DEFAULT="ghcr.io/danyial/mowglinext/mowglinext-gui:${IMAGE_TAG}"
+}
+
+# Initial derivation — re-runs at end of parse_args() to pick up overrides.
+derive_image_defaults
 
 CHECK_ONLY=false
 CLI_PRESET=false
@@ -51,6 +78,10 @@ parse_args() {
         ;;
       --branch=*)
         REPO_BRANCH="${1#*=}"
+        ;;
+      --image-tag=*)
+        IMAGE_TAG="${1#*=}"
+        IMAGE_TAG_EXPLICIT=true
         ;;
       --lang=*)
         MOWGLI_LANG="${1#*=}"
@@ -156,6 +187,9 @@ parse_args() {
   if [[ "$CLI_PRESET" == "true" ]]; then
     PRESET_LOADED=true
   fi
+
+  # Re-derive image defaults so --branch= / --image-tag= overrides take effect.
+  derive_image_defaults
 }
 
 # Track issues for the final summary


### PR DESCRIPTION
## Bug
\`*_IMAGE_DEFAULT\` constants in \`config.sh\` baked \`:main\` into the tag at source time. \`setup_env()\` wrote those into \`.env\` verbatim, so a fresh installer run on this fork (which only publishes \`:dev\` tags so far) produced a \`.env\` that pulled from \`ghcr.io/danyial/mowglinext/...:main\` — a tag that doesn't exist in this fork's GHCR namespace. Manual workaround was \`sed -i 's|:main$|:dev|g' .env\` after every run.

## Fix
\`IMAGE_TAG\` is now derived from \`REPO_BRANCH\` inside a \`derive_image_defaults()\` function that runs both on initial source **and** at the end of \`parse_args()\`, so \`--branch=\` / \`--image-tag=\` overrides take effect on the constants the rest of the installer reads.

Precedence (highest wins):
1. \`--image-tag=<tag>\` CLI flag
2. \`IMAGE_TAG\` env var
3. \`REPO_BRANCH\` if it's \`main\` or \`dev\` (matches what CI actually publishes)
4. \`main\` fallback for feature branches without published tags (with this default the install still works — pulls the stable tag)

The ublox \`GPS_IMAGE_DEFAULT\` stays pinned to upstream \`cedbossneo:main\` regardless of \`IMAGE_TAG\` — see PR #4 for why this fork's CI doesn't build the ublox image.

## Smoke test
\`\`\`
auto-detect on dev clone           → REPO_BRANCH=dev IMAGE_TAG=dev
--branch=dev                       → REPO_BRANCH=dev IMAGE_TAG=dev
--branch=feat/foo                  → REPO_BRANCH=feat/foo IMAGE_TAG=main (fallback)
--branch=feat/bar --image-tag=v1   → REPO_BRANCH=feat/bar IMAGE_TAG=v1 (explicit wins)
IMAGE_TAG=staging --branch=dev     → REPO_BRANCH=dev IMAGE_TAG=staging (env sticks)
\`\`\`

## Test plan
- [ ] On Pi clone checked out to \`dev\`: \`./mowglinext.sh --gps=nmea-usb --lidar=ldlidar-uart\` → \`.env\` ends up with \`:dev\` tags, \`docker compose pull\` succeeds without \`sed\` workaround.
- [ ] No regression for users on \`main\`: same install ends up with \`:main\` tags as before.