### PR TITLE
fix(gps-nmea): make parse_yaml resilient to missing keys

### DIFF
--- a/sensors/gps-nmea/start_gps_nmea.sh
+++ b/sensors/gps-nmea/start_gps_nmea.sh
@@ -14,7 +14,14 @@ CONFIG="/config/mowgli_robot.yaml"
 [ -f "$CONFIG" ] || { echo "[gps-nmea] $CONFIG missing — bind-mount install/config/mowgli to /config"; exit 1; }
 
 parse_yaml() {
-  grep -E "^\s+${1}:" "$CONFIG" 2>/dev/null | head -1 | sed 's/.*:\s*//' | tr -d '"' | tr -d "'"
+  # Pipefail-safe: grep returns 1 when the key is missing, which would kill
+  # the script (set -euo pipefail). Capture and short-circuit instead, so a
+  # missing key just yields an empty string — defaults at the bottom of the
+  # block then take over.
+  local line
+  line=$(grep -E "^\s+${1}:" "$CONFIG" 2>/dev/null | head -1) || true
+  [ -n "$line" ] || return 0
+  echo "$line" | sed 's/.*:\s*//' | tr -d '"' | tr -d "'"
 }
 
 GPS_PORT=$(parse_yaml gps_port)


### PR DESCRIPTION
## Bug
\`start_gps_nmea.sh\`'s \`parse_yaml\` is a \`grep | head | sed | tr | tr\` pipeline. When the requested key is absent from \`mowgli_robot.yaml\`, \`grep\` exits with status 1, \`pipefail\` propagates that, \`set -e\` kills the script — and because the failure is at line 22 (during config-parse), the script dies **before printing anything**, leaving an empty container log and an opaque restart loop.

Caught on hardware: my own UM980 install hit it because the existing config didn't contain \`gps_frame_id\` (key was added in a later iteration). \`docker logs mowgli-gps\` returned 0 bytes; only \`bash -x\` traced the silent exit.

## Fix
Capture grep output via \`local line=...\`, swallow the non-zero exit with \`|| true\`, return early when empty. Missing keys now fall through to the bottom-of-block defaults (\`\${GPS_FRAME:-gps_link}\`, \`\${NTRIP_ENABLED:-false}\`, etc.) as the script's structure intended all along.

## Smoke test
\`\`\`
yaml { gps_port + gps_baudrate + ntrip_enabled, no gps_frame_id }
→ gps_port='/dev/gps' gps_frame_id='' (empty → uses gps_link default)
\`\`\`

Old behavior on the same input: silent script exit, empty container log, restart loop.

## Test plan
- [ ] Container starts even when yaml is missing optional keys
- [ ] Existing yamls with all keys present behave identically