### PR TITLE
fix(install): drop stale lidar command override

### DIFF
--- a/install/compose/docker-compose.lidar-ldlidar.yml
+++ b/install/compose/docker-compose.lidar-ldlidar.yml
@@ -22,16 +22,14 @@ services:
     privileged: true
     environment:
       <<: *ros2-env
-    command: >
-      ros2 run ldlidar_stl_ros2 ldlidar_stl_ros2_node
-      --ros-args
-      -p product_name:=LDLiDAR_LD19
-      -p topic_name:=scan
-      -p frame_id:=lidar_link
-      -p port_name:=${LIDAR_PORT:-/dev/lidar}
-      -p port_baudrate:=${LIDAR_BAUD:-230400}
-      -p laser_scan_dir:=true
-      -p enable_angle_crop_func:=false
+    # No `command:` override — the image's CMD is /start_lidar.sh which calls
+    # `ros2 launch /ldlidar_scan.launch.py` with the Myzhar/ldrobot-lidar-ros2
+    # lifecycle driver (see sensors/lidar-ldlidar/Dockerfile). The previous
+    # override invoked `ros2 run ldlidar_stl_ros2 ldlidar_stl_ros2_node` —
+    # that's the older ldrobotSensorTeam driver, which is not in this image
+    # and produces variable scan length anyway (slam_toolbox rejects it).
+    # To customise: edit /ldlidar.yaml inside the image, or rebuild with a
+    # different launch file — don't re-add `command:` here.
     volumes:
       - /dev:/dev
       - ./config/cyclonedds.xml:/cyclonedds.xml:ro


### PR DESCRIPTION
## Bug
\`install/compose/docker-compose.lidar-ldlidar.yml\` overrode the container CMD with:
\`\`\`
ros2 run ldlidar_stl_ros2 ldlidar_stl_ros2_node ...
\`\`\`
…but the \`sensors/lidar-ldlidar/\` image was switched to **Myzhar/ldrobot-lidar-ros2** (see Dockerfile rationale: variable scan length on the older driver broke slam_toolbox's Karto). The new image's CMD is \`/start_lidar.sh\` → \`ros2 launch /ldlidar_scan.launch.py\` with the Myzhar lifecycle driver. The old override called a node that doesn't exist in the new image.

Symptom on the Pi: \`Package 'ldlidar_stl_ros2' not found\` restart loop.

## Fix
Drop the \`command:\` override. The image's CMD takes over and the lifecycle node loads cleanly. Comment block is in place so this doesn't get re-added.

## Test plan
- [x] On Pi: \`docker compose up -d --force-recreate lidar\` → container stays Up, \`/scan\` published at ~10 Hz with \`frame_id: lidar_link\` (verified live).
- [ ] No regression for users who customized other settings — they only need to re-run the installer to regenerate \`docker-compose.yaml\`.