### PR TITLE
fix(firmware): bump arm-none-eabi toolchain to gcc 12 for arm64 hosts

### DIFF
--- a/firmware/stm32/ros_usbnode/platformio.ini
+++ b/firmware/stm32/ros_usbnode/platformio.ini
@@ -27,7 +27,13 @@ build_src_filter =
 [env:Yardforce500]
 board = genericSTM32F103VC
 platform_packages = 
-    toolchain-gccarmnoneeabi@~1.90301.0
+    ; gcc-arm-none-eabi 12.3 — first ARM-distributed toolchain with
+    ; native aarch64-linux builds. The previous pin (~1.90301.0 / gcc
+    ; 9.3.1, July 2020) is x86_64-only, so building/flashing from a
+    ; Pi5 host (arm64) ran the compiler under QEMU and segfaulted on
+    ; larger HAL files. gcc 12 still cleanly builds the STM32F1 USB
+    ; CDC + ROS-serial code paths.
+    toolchain-gccarmnoneeabi@~1.120301.0
 	platformio/tool-stm32duino@^1.0.1
 	platformio/tool-openocd@^2.1100.211028
 	platformio/tool-dfuutil@^1.11.0
@@ -42,7 +48,8 @@ monitor_port = /dev/ttyAMA0
 [env:Yardforce500B]
 board = genericSTM32F401VC
 platform_packages =
-	toolchain-gccarmnoneeabi@~1.90301.0
+	; See Yardforce500 env above for the toolchain-bump rationale (arm64 host support).
+	toolchain-gccarmnoneeabi@~1.120301.0
 	platformio/tool-stm32duino@^1.0.1
 	platformio/tool-openocd@^2.1100.211028
 	platformio/tool-dfuutil@^1.11.0


### PR DESCRIPTION
## Bug
\`firmware/stm32/ros_usbnode/platformio.ini\` pinned:
\`\`\`ini
toolchain-gccarmnoneeabi@~1.90301.0
\`\`\`
That's gcc-arm-none-eabi 9.3.1 (July 2020) — **x86_64-linux only**, no aarch64 build. Flashing from a Pi5 host runs the compiler under QEMU and segfaults on larger HAL sources:

\`\`\`
Compiling .pio/build/Yardforce500/FrameworkHALDriver/Src/stm32f1xx_hal.o
Segmentation fault
*** [.pio/build/Yardforce500/.../stm32f1xx_hal.o] Error 139
\`\`\`

This bites anyone using the GUI's "Flash firmware" button from an arm64 host (Pi5 is the project's primary deployment target — see \`README.md\`).

## Fix
Bump both \`Yardforce500\` and \`Yardforce500B\` envs to \`~1.120301.0\` — gcc-arm-none-eabi 12.3.1, the first ARM-distributed toolchain with native \`aarch64-linux\` builds. Pi5 hosts now compile natively, no QEMU.

gcc 12.x cleanly builds the STM32F1/F4 stm32cube + USB CDC + ros-serial code paths in this repo (well-tested combination — STM32 vendor stm32cube has supported gcc ≥ 9 for years). x86_64 hosts also benefit from the newer toolchain.

\`Yardforce500_REMOTE_UPLOAD\` env is unchanged — it has no toolchain pin and uses the platform default (which already auto-selects the right arch).

## Test plan
- [ ] Trigger "Flash firmware" via GUI from the Pi5 → build completes, firmware uploads to STM32 via stlink without segfault.
- [ ] x86_64 build (CI / dev container) still produces a working binary.
- [ ] Mowgli-side functionality post-flash: blade safety, CDC enumeration as \`/dev/mowgli\`, ros-serial topics resume.