### PR TITLE
fix(gps-nmea): restore RTK Float vs Fixed distinction in /gps/fix.status

### DIFF
--- a/sensors/gps-nmea/nmea_serial_bridge.py
+++ b/sensors/gps-nmea/nmea_serial_bridge.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python3
 # =============================================================================
-# NMEA serial bridge: reads NMEA sentences from /dev/gps and republishes them
-# as nmea_msgs/Sentence on /nmea_sentence for downstream consumers
-# (nmea_navsat_driver's nmea_topic_driver).
+# NMEA serial bridge — two jobs:
 #
-# Why a separate bridge instead of nmea_navsat_driver's built-in nmea_serial_driver?
+# 1. Read NMEA from /dev/gps, republish raw sentences on /nmea_sentence so
+#    nmea_navsat_driver can convert them to NavSatFix.
+#
+# 2. Republish nmea_navsat_driver's NavSatFix on /gps/fix with the
+#    status.status field corrected to reflect the GGA quality field.
+#    nmea_navsat_driver's upstream behavior maps both Q=4 (RTK Fixed) and
+#    Q=5 (RTK Float) to STATUS_GBAS_FIX (=2), losing the distinction
+#    downstream consumers (FusionCore, navsat_to_absolute_pose, GUI) need
+#    to gate Fixed-only logic. We track the last seen GGA quality here
+#    and overwrite status.status before republishing.
+#
+# Why a separate bridge instead of nmea_navsat_driver's built-in serial
+# reader?
 # - We want the raw sentences on a topic (debugging, logging, future consumers).
 # - We control QoS explicitly (RELIABLE) — Cyclone DDS rejects RELIABLE
 #   subscribers paired with BEST_EFFORT publishers, and FusionCore /
@@ -12,6 +22,8 @@
 #   for the same fix on the ublox side.
 # - We add automatic reconnect on serial errors (USB hot-unplug, kernel
 #   re-enumeration after str2str write bursts).
+# - We need the GGA quality field (see point 2) which the upstream driver
+#   silently collapses.
 # =============================================================================
 
 import threading
@@ -22,8 +34,27 @@ import serial
 from nmea_msgs.msg import Sentence
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+from sensor_msgs.msg import NavSatFix, NavSatStatus
 
 RECONNECT_DELAY_S = 1.0
+
+# NMEA-0183 GGA quality field → sensor_msgs/NavSatStatus.status mapping.
+# This matches what navsat_to_absolute_pose_node.cpp expects:
+#   STATUS_GBAS_FIX (2) → FLAG_GPS_RTK_FIXED
+#   STATUS_SBAS_FIX (1) → FLAG_GPS_RTK_FLOAT
+#   STATUS_FIX      (0) → FLAG_GPS_RTK   (generic)
+#   STATUS_NO_FIX  (-1) → no flags
+# nmea_navsat_driver upstream collapses both Q=4 and Q=5 to STATUS_GBAS_FIX,
+# losing Float-vs-Fixed signal — we restore it.
+GGA_QUALITY_TO_STATUS = {
+    0: NavSatStatus.STATUS_NO_FIX,    # invalid / no fix
+    1: NavSatStatus.STATUS_FIX,        # autonomous (SPS)
+    2: NavSatStatus.STATUS_FIX,        # DGPS — has corrections but not RTK
+    3: NavSatStatus.STATUS_FIX,        # PPS (rare)
+    4: NavSatStatus.STATUS_GBAS_FIX,   # RTK Fixed → ~3 mm
+    5: NavSatStatus.STATUS_SBAS_FIX,   # RTK Float → 0.5–2 m
+    6: NavSatStatus.STATUS_FIX,        # estimated / dead reckoning
+}
 
 
 class NmeaSerialBridge(Node):
@@ -45,9 +76,43 @@ class NmeaSerialBridge(Node):
         )
         self._pub = self.create_publisher(Sentence, "nmea_sentence", qos)
 
+        # GGA quality tracking — updated from the serial reader, read by the
+        # /gps/fix_raw subscriber. Default to 1 (autonomous) so a missing
+        # GGA stream doesn't accidentally elevate any pre-existing fix to RTK.
+        self._last_quality = 1
+        self._quality_lock = threading.Lock()
+
+        # NavSatFix passthrough: subscribe to nmea_navsat_driver's output
+        # (remapped to /gps/fix_raw in start_gps_nmea.sh) and republish on
+        # /gps/fix with status.status overwritten from the live GGA quality.
+        self._fix_pub = self.create_publisher(NavSatFix, "/gps/fix", qos)
+        self._fix_sub = self.create_subscription(
+            NavSatFix, "/gps/fix_raw", self._on_fix_raw, qos
+        )
+
         self._stop = threading.Event()
         self._reader = threading.Thread(target=self._read_loop, daemon=True)
         self._reader.start()
+
+    @staticmethod
+    def _gga_quality(line: str) -> int | None:
+        # GGA layout: $G[NP]GGA,utc,lat,N/S,lon,E/W,quality,...
+        # Field index 6 is the quality digit (0..6/7/8 depending on receiver).
+        if len(line) < 7 or line[3:6] != "GGA":
+            return None
+        parts = line.split(",")
+        if len(parts) < 7:
+            return None
+        try:
+            return int(parts[6])
+        except ValueError:
+            return None
+
+    def _on_fix_raw(self, msg: NavSatFix) -> None:
+        with self._quality_lock:
+            q = self._last_quality
+        msg.status.status = GGA_QUALITY_TO_STATUS.get(q, NavSatStatus.STATUS_FIX)
+        self._fix_pub.publish(msg)
 
     def _read_loop(self) -> None:
         while not self._stop.is_set():
@@ -63,6 +128,11 @@ class NmeaSerialBridge(Node):
                         line = raw.decode("ascii", errors="replace").strip()
                         if not line.startswith("$"):
                             continue
+                        # Track GGA quality for the NavSatFix republisher.
+                        q = self._gga_quality(line)
+                        if q is not None:
+                            with self._quality_lock:
+                                self._last_quality = q
                         msg = Sentence()
                         msg.header.stamp = self.get_clock().now().to_msg()
                         msg.header.frame_id = self._frame_id

--- a/sensors/gps-nmea/start_gps_nmea.sh
+++ b/sensors/gps-nmea/start_gps_nmea.sh
@@ -3,8 +3,12 @@
 # NMEA GPS startup. Reads config from /config/mowgli_robot.yaml.
 #
 # Launches:
-#   1. nmea_serial_bridge.py    /dev/gps → /nmea_sentence (RELIABLE)
-#   2. nmea_topic_driver        /nmea_sentence → /gps/fix (NavSatFix)
+#   1. nmea_serial_bridge.py    /dev/gps → /nmea_sentence  (RELIABLE)
+#                               /gps/fix_raw → /gps/fix    (status corrected)
+#   2. nmea_topic_driver        /nmea_sentence → /gps/fix_raw  (NavSatFix)
+#                               (raw because upstream driver maps Q=4 and Q=5
+#                                both to STATUS_GBAS_FIX — the bridge restores
+#                                the Float vs Fixed distinction)
 #   3. str2str (NTRIP)          NTRIP caster → RTCM3 → /dev/gps (write side)
 #   + inotify watcher reloads str2str when ntrip_* keys in the YAML change.
 # =============================================================================
@@ -44,16 +48,17 @@ python3 /nmea_serial_bridge.py --ros-args \
   -p frame_id:="${GPS_FRAME}" &
 BRIDGE_PID=$!
 
-# 2. nmea_navsat_driver topic mode: /nmea_sentence → /gps/fix.
-#    Trust the driver's default publisher QoS (RELIABLE in current upstream).
-#    If FusionCore stops receiving fixes after upstream changes, switch to a
-#    bespoke NavSatFix publisher inside nmea_serial_bridge.py.
+# 2. nmea_navsat_driver topic mode: /nmea_sentence → /gps/fix_raw.
+#    The bridge above re-publishes /gps/fix_raw as /gps/fix with a corrected
+#    status.status field (Q=5 → SBAS_FIX = RTK Float, Q=4 → GBAS_FIX = RTK
+#    Fixed). Upstream collapses both to GBAS_FIX, which mis-flags Float
+#    fixes as Fixed in navsat_to_absolute_pose and the GUI.
 ros2 run nmea_navsat_driver nmea_topic_driver --ros-args \
   -p frame_id:="${GPS_FRAME}" \
   -p time_ref_source:=gps \
   -p useRMC:=false \
   -p use_GNSS_time:=false \
-  -r /fix:=/gps/fix \
+  -r /fix:=/gps/fix_raw \
   -r /vel:=/gps/vel \
   -r /time_reference:=/gps/time_reference &
 DRIVER_PID=$!


### PR DESCRIPTION
## Bug
\`nmea_navsat_driver\` collapses GGA quality 4 (RTK Fixed) and 5 (RTK Float) both onto \`sensor_msgs/NavSatStatus.STATUS_GBAS_FIX (=2)\`. That status is what \`navsat_to_absolute_pose_node.cpp\` maps to \`FLAG_GPS_RTK_FIXED\` — so the GUI shows "RTK FIX" in both cases, even when the receiver is just RTK Float (~0.5–2 m).

Caught on real hardware: my UM980 sat at GGA Q=5 (Float, σ ≈ 0.8 m) for 20 minutes and the GUI happily said "RTK FIX". Only \`ros2 topic echo /nmea_sentence\` revealed the truth.

This matters beyond cosmetics: FusionCore has a 2 cm covariance floor on Fixed updates (CLAUDE.md invariant). If Float fixes get flagged as Fixed, the floor blocks legitimate Float-grade covariance, the UKF rejects them, position drifts.

## Fix
Track GGA quality field while reading the serial stream; republish nmea_navsat_driver's NavSatFix on \`/gps/fix\` with \`status.status\` overwritten:

| GGA Q | NavSatStatus | AbsolutePose flag | Display |
|-------|--------------|-------------------|---------|
| 4 | STATUS_GBAS_FIX (2) | FLAG_GPS_RTK_FIXED | "RTK FIX" |
| 5 | STATUS_SBAS_FIX (1) | FLAG_GPS_RTK_FLOAT | "RTK FLOAT" |
| 2 | STATUS_FIX (0) | FLAG_GPS_RTK | "GPS FIX" (DGPS) |
| 1 | STATUS_FIX (0) | FLAG_GPS_RTK | "GPS FIX" (autonomous) |
| 0 | STATUS_NO_FIX (-1) | (none) | "No Fix" |

Topic flow:
\`\`\`
nmea_topic_driver  /nmea_sentence → /gps/fix_raw   (was → /gps/fix)
nmea_serial_bridge /gps/fix_raw   → /gps/fix       (status corrected)
\`\`\`
Downstream consumers (FusionCore, navsat_to_absolute_pose, GUI) see no topic-name change. GUI needs no edits — \`navsat_to_absolute_pose_node\` already maps \`STATUS_SBAS_FIX\` → \`FLAG_GPS_RTK_FLOAT\` and the GUI already renders that flag as "RTK FLOAT".

The ublox image (\`sensors/gps/\`) already does this correctly because \`ublox_dgnss\` reports \`carrSoln\` distinctly via UBX-NAV-STATUS — see the comment block in the file. This PR brings the NMEA path to parity.

## Smoke test (offline)
\`\`\`
$GNGGA,...,5,...   → quality=5 ✓
$GNGGA,...,4,...   → quality=4 ✓
$GNGGA,...,0,...   → quality=0 ✓
$GAGSV,...         → None (not GGA) ✓
$GNRMC,...         → None (not GGA) ✓
\`\`\`

## Test plan (live, after merge or local image build)
- [ ] When \`/nmea_sentence\` shows GGA Q=4: \`/gps/fix.status.status\` = 2, GUI shows "RTK FIX"
- [ ] When \`/nmea_sentence\` shows GGA Q=5: \`/gps/fix.status.status\` = 1, GUI shows "RTK FLOAT"
- [ ] No regression for ublox path (this PR doesn't touch sensors/gps/)