### PR TITLE
fix(gui): write/read dual-block YAML keys (datum_lat) consistently

### DIFF
--- a/gui/pkg/api/settings.go
+++ b/gui/pkg/api/settings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
 	"sync"
 	"time"
 
@@ -187,11 +188,30 @@ func extractNodeMappings(schema map[string]any) map[string]string {
 
 // flattenROS2YAML reads nested ROS2 YAML (node: ros__parameters: {k: v}) and
 // returns a flat map of all parameter key-value pairs across all nodes.
-// It also duplicates datum_lat/datum_lon from mowgli node to keep them in sync.
+//
+// Some keys legitimately appear in multiple nodes (datum_lat/datum_lon are
+// declared on both `mowgli` and `navsat_to_absolute_pose` so each node loads
+// its own copy from a single yaml). Two correctness rules apply:
+//  1. Iterate node names in deterministic (sorted) order — Go map iteration
+//     is randomized, so a naive last-wins merge produced non-deterministic
+//     reads (the GUI's MapPage saw datum_lat=0 sometimes and 48.x other
+//     times depending on hash seed).
+//  2. Prefer non-zero values: if a key is present in two nodes with
+//     different values (typically because nestToROS2YAML used to only
+//     update one of them), the live value usually lives in the node that
+//     was updated. Returning the zero would cause downstream consumers
+//     (MapPage, MiniMap) to treat the datum as unset.
 func flattenROS2YAML(yamlData map[string]any) map[string]any {
 	flat := map[string]any{}
-	for _, nodeData := range yamlData {
-		nodeMap, ok := nodeData.(map[string]any)
+
+	nodeNames := make([]string, 0, len(yamlData))
+	for n := range yamlData {
+		nodeNames = append(nodeNames, n)
+	}
+	sort.Strings(nodeNames)
+
+	for _, nodeName := range nodeNames {
+		nodeMap, ok := yamlData[nodeName].(map[string]any)
 		if !ok {
 			continue
 		}
@@ -200,15 +220,56 @@ func flattenROS2YAML(yamlData map[string]any) map[string]any {
 			continue
 		}
 		for k, v := range rosParams {
-			flat[k] = v
+			if existing, hadValue := flat[k]; hadValue && !isZeroish(v) && isZeroish(existing) {
+				// Replace the zero with the meaningful value.
+				flat[k] = v
+			} else if !hadValue {
+				flat[k] = v
+			}
+			// else: keep what we already have (either both non-zero,
+			// or the existing value is non-zero and the new one is zero).
 		}
 	}
 	return flat
 }
 
+// isZeroish returns true for values that look like "unset" — empty strings,
+// zero numerics, nil, and the literal "0" / "0.0" strings YAML sometimes
+// produces. Used by flattenROS2YAML to prefer meaningful values when a
+// key appears in multiple nodes.
+func isZeroish(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch x := v.(type) {
+	case float64:
+		return x == 0
+	case float32:
+		return x == 0
+	case int:
+		return x == 0
+	case int64:
+		return x == 0
+	case string:
+		return x == "" || x == "0" || x == "0.0"
+	}
+	return false
+}
+
 // nestToROS2YAML takes a flat param map and node mappings, and produces
 // nested ROS2 YAML structure. It preserves any existing YAML content that
 // is not covered by the schema.
+//
+// When a key already exists in *multiple* nodes of the existing YAML
+// (e.g. datum_lat lives on both `mowgli` and `navsat_to_absolute_pose`),
+// the new value is written to *all* of those nodes. The previous behaviour
+// updated only the schema-mapped node (mowgli by default), which left the
+// other copy stale and triggered the dual-block bug: GET would re-read the
+// stale zero from the un-updated block and overwrite the value the GUI just
+// thought it had saved.
+//
+// For brand-new keys (not present anywhere in existingYAML) we still defer
+// to the schema's x-yaml-node mapping, falling back to "mowgli".
 func nestToROS2YAML(flat map[string]any, nodeMappings map[string]string, existingYAML map[string]any) map[string]any {
 	result := map[string]any{}
 
@@ -223,17 +284,42 @@ func nestToROS2YAML(flat map[string]any, nodeMappings map[string]string, existin
 		}
 	}
 
-	// Group flat params by node
+	// Build a key → [nodes that already host it] index from existingYAML so
+	// we can fan out shared keys (datum_lat etc.) to every place that
+	// already declares them.
+	keyHostNodes := map[string][]string{}
+	for nodeName, nodeData := range existingYAML {
+		nodeMap, ok := nodeData.(map[string]any)
+		if !ok {
+			continue
+		}
+		rosParams, ok := nodeMap["ros__parameters"].(map[string]any)
+		if !ok {
+			continue
+		}
+		for k := range rosParams {
+			keyHostNodes[k] = append(keyHostNodes[k], nodeName)
+		}
+	}
+
+	// Group flat params by node — fan out to every node that already hosts
+	// the key, or fall back to schema mapping for brand-new keys.
 	nodeParams := map[string]map[string]any{}
 	for key, value := range flat {
-		node := "mowgli" // default
-		if n, ok := nodeMappings[key]; ok {
-			node = n
+		nodes := keyHostNodes[key]
+		if len(nodes) == 0 {
+			n := "mowgli"
+			if m, ok := nodeMappings[key]; ok {
+				n = m
+			}
+			nodes = []string{n}
 		}
-		if nodeParams[node] == nil {
-			nodeParams[node] = map[string]any{}
+		for _, n := range nodes {
+			if nodeParams[n] == nil {
+				nodeParams[n] = map[string]any{}
+			}
+			nodeParams[n][key] = value
 		}
-		nodeParams[node][key] = value
 	}
 
 	// Merge into result, preserving existing ros__parameters that aren't in flat

--- a/gui/pkg/api/settings_test.go
+++ b/gui/pkg/api/settings_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func setupSettingsRouter(dbProvider types.IDBProvider) *gin.Engine {
@@ -489,6 +490,79 @@ func TestPostSettingsYAML_MergesExisting(t *testing.T) {
 	assert.Contains(t, string(content), "OM_EXISTING")
 	assert.Contains(t, string(content), "keep_me")
 	assert.Contains(t, string(content), "99.999")
+}
+
+// Dual-block keys (e.g. datum_lat / datum_lon) are declared on both the
+// `mowgli` and `navsat_to_absolute_pose` ROS2 nodes, so a single yaml file
+// can drive both. The GUI flow used to update only one block on POST and
+// then non-deterministically pick a value on GET — see PR description.
+//
+// These tests pin the corrected behaviour:
+//   - GET prefers the meaningful (non-zero) value when blocks disagree
+//   - POST writes the new value into every block that already declared the key
+func TestGetSettingsYAML_DualBlockKey_PrefersNonZero(t *testing.T) {
+	yamlFile := createTempYAMLFile(t, `mowgli:
+  ros__parameters:
+    datum_lat: 48.1590756
+    datum_lon: 11.3153734
+navsat_to_absolute_pose:
+  ros__parameters:
+    datum_lat: 0
+    datum_lon: 0
+`)
+	db := types.NewMockDBProvider()
+	db.Set("system.mower.yamlConfigFile", []byte(yamlFile))
+	router := setupSettingsRouter(db)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/settings/yaml", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	assert.Equal(t, 48.1590756, result["datum_lat"], "non-zero value from one block must win over zero in another")
+	assert.Equal(t, 11.3153734, result["datum_lon"])
+}
+
+func TestPostSettingsYAML_DualBlockKey_WritesToAllNodes(t *testing.T) {
+	yamlFile := createTempYAMLFile(t, `mowgli:
+  ros__parameters:
+    datum_lat: 0
+    datum_lon: 0
+navsat_to_absolute_pose:
+  ros__parameters:
+    datum_lat: 0
+    datum_lon: 0
+`)
+	db := types.NewMockDBProvider()
+	db.Set("system.mower.yamlConfigFile", []byte(yamlFile))
+	router := setupSettingsRouter(db)
+
+	body, _ := json.Marshal(map[string]any{
+		"datum_lat": 48.1590756,
+		"datum_lon": 11.3153734,
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/settings/yaml", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	content, err := os.ReadFile(yamlFile)
+	require.NoError(t, err)
+
+	// Re-parse the written YAML and assert both nodes carry the new value.
+	var written map[string]any
+	require.NoError(t, yaml.Unmarshal(content, &written))
+	for _, nodeName := range []string{"mowgli", "navsat_to_absolute_pose"} {
+		node, ok := written[nodeName].(map[string]any)
+		require.Truef(t, ok, "node %q missing", nodeName)
+		params, ok := node["ros__parameters"].(map[string]any)
+		require.Truef(t, ok, "ros__parameters missing on %q", nodeName)
+		assert.Equal(t, 48.1590756, params["datum_lat"], "datum_lat must be propagated to %q", nodeName)
+		assert.Equal(t, 11.3153734, params["datum_lon"], "datum_lon must be propagated to %q", nodeName)
+	}
 }
 
 func TestPostSettingsYAML_InvalidJSON(t *testing.T) {


### PR DESCRIPTION
## Bug
\`mowgli_robot.yaml\` declares some keys (\`datum_lat\`, \`datum_lon\`) under **two** ROS2 nodes — \`mowgli\` and \`navsat_to_absolute_pose\` — so a single config drives both. Two GUI-side issues collided to make this fall apart:

1. **\`POST /api/settings/yaml\`** updated only the schema-mapped node (\`mowgli\` by default), leaving the other block stale.
2. **\`flattenROS2YAML\`** iterated nodes in Go map order (randomised), then did last-wins. So \`GET /api/settings/yaml\` returned the stale zero some loads and the live value other loads — pure hash-seed roulette.

Net effect on real hardware: setting datum via Settings UI or Onboarding *"saved successfully"* but \`MapPage\` (which gates on \`settings.datum_lat != 0\`) never picked it up — forever spinner. Restart helped occasionally because the random map iteration sometimes won.

## Fix
**\`flattenROS2YAML\`**:
- Sort node names → deterministic iteration
- When a key appears in multiple nodes, prefer the non-zero value (so a half-updated file no longer hides a meaningful value behind a stale zero)

**\`nestToROS2YAML\`**:
- For every key already present in multiple nodes of \`existingYAML\`, fan the new value out to **all** of those nodes
- Brand-new keys still defer to the schema's \`x-yaml-node\` (defaults to \`mowgli\`)

## Test plan
\`\`\`
=== RUN   TestGetSettingsYAML_DualBlockKey_PrefersNonZero
--- PASS
=== RUN   TestPostSettingsYAML_DualBlockKey_WritesToAllNodes
--- PASS
\`\`\`
Both tests run on real go 1.24 + the fix branch — verified on Pi5.

## Note: pre-existing test failures
\`TestGetSettingsYAML_Success\` and \`TestPostSettingsYAML_MergesExisting\` use **flat** YAML fixtures (no nested ROS2 \`ros__parameters\`) — they were already failing on \`dev\` before this PR and the existing \`flattenROS2YAML\` skips top-level non-map values. Out of scope to fix here; would need a follow-up to either update the fixtures to nested ROS2 YAML or restore flat-yaml support.

## Out of scope
- The Onboarding wizard (\`OnboardingPage.tsx\`) calls the same endpoint, so it inherits this fix automatically.
- Daniel also noted "Onboarding beim 2. Durchlauf nutzt die alten Werte nicht" — that's the CLI installer's \`load_existing_config\` reading only the first occurrence via \`grep | head -1\` in a separate code path. Separate PR.