### PR TITLE
fix(gui): propagate dock drag updates into features state

### DIFF
--- a/gui/web/src/pages/map/hooks/useMapEditing.ts
+++ b/gui/web/src/pages/map/hooks/useMapEditing.ts
@@ -10,6 +10,7 @@ import type MapboxDraw from "@mapbox/mapbox-gl-draw";
 import type {Map as MapboxMap} from 'mapbox-gl';
 import {emojiToPolygon} from '../utils/emojiToPolygon';
 import {
+    DockFeatureBase,
     MowingFeature,
     MowingAreaFeature,
     MowingFeatureBase,
@@ -602,14 +603,30 @@ export function useMapEditing({
                 const newFeatures = {...currFeatures};
                 for (const f of e.features) {
                     const feature = newFeatures[f.id as string];
+                    // Polygon edits (areas, obstacles, navigation zones)
                     if (
-                        !(feature instanceof MowingAreaFeature) &&
-                        !(feature instanceof ObstacleFeature) &&
-                        !(feature instanceof NavigationFeature)
-                    )
+                        feature instanceof MowingAreaFeature ||
+                        feature instanceof ObstacleFeature ||
+                        feature instanceof NavigationFeature
+                    ) {
+                        if (f.geometry.type === "Polygon") {
+                            feature.setGeometry(f.geometry as Polygon);
+                        }
                         continue;
-                    if (f.geometry.type === "Polygon") {
-                        feature.setGeometry(f.geometry as Polygon);
+                    }
+                    // Dock drag: keep heading from prior state, replace coords
+                    // with the new dragged position. Without this branch the
+                    // dragged coordinates were lost and Save sent (0,0,0) to
+                    // /map_server_node/set_docking_point.
+                    if (
+                        feature instanceof DockFeatureBase &&
+                        f.geometry.type === "Point"
+                    ) {
+                        const c = f.geometry.coordinates as [number, number];
+                        newFeatures[f.id as string] = new DockFeatureBase(
+                            c,
+                            feature.getHeading()
+                        );
                     }
                 }
                 return newFeatures;


### PR DESCRIPTION
## Bug
Dragging the dock marker on the Map appears to work, but Save snaps it back to the original position.

Hardware log proves Save sends zeros to ROS:
\`\`\`
[map_server_node]: Docking point set: (0.000, 0.000, 0.000)
                   orientation (0.000, 0.000, 0.000, 0.000)
\`\`\`

Root cause: DrawControl's \`draw.update\` event fires when the dock marker is dragged, but \`useMapEditing.onUpdate\` only matched \`MowingAreaFeature\` / \`ObstacleFeature\` / \`NavigationFeature\` — DockFeature hits the early \`continue\` and the new coordinates are dropped. \`features['dock']\` keeps the initial coords (often \`[0,0]\` if datum isn't loaded yet), Save reads them, sends \`(0,0,0)\` to the service, /map re-publishes the old dock, GUI re-renders at original spot. Looks like a silent rejection.

## Fix
Extend \`onUpdate\` to handle \`Point\` geometry on \`DockFeatureBase\`. Replace the stale feature with a new \`DockFeatureBase\` carrying the dragged coordinates plus the heading preserved from the prior feature.

## Test plan
- [ ] Drag dock marker on map, click Save → \`docker logs mowgli-ros2 | grep Docking\` shows the actual dragged coords (not zeros).
- [ ] Dock marker stays at the new position after Save (no snap-back).
- [ ] Heading-rotation still works (preserved across drag).
- [ ] Polygon drag of areas/obstacles unaffected (separate branch in the same handler).