### PR TITLE
fix(gui): dock pose saves correctly (snake_case unmarshal + CDR float64 alignment)

### DIFF
--- a/gui/pkg/api/utils.go
+++ b/gui/pkg/api/utils.go
@@ -31,10 +31,16 @@ func unmarshalROSMessage[T any](reader io.ReadCloser, out T) error {
 	if err != nil {
 		return err
 	}
+	// Match struct fields against incoming map keys ignoring both case and
+	// underscores so PascalCase Go fields (DockingPose) match snake_case
+	// rosbridge keys (docking_pose) as well as camelCase variants.
+	normalize := func(s string) string {
+		return strings.ReplaceAll(strings.ToLower(s), "_", "")
+	}
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Result: out,
 		MatchName: func(mapKey, fieldName string) bool {
-			return strings.ToLower(fieldName) == strings.ToLower(mapKey)
+			return normalize(fieldName) == normalize(mapKey)
 		},
 	})
 	err = decoder.Decode(m)

--- a/gui/pkg/api/utils_nested_test.go
+++ b/gui/pkg/api/utils_nested_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cedbossneo/mowglinext/pkg/msgs/geometry"
+	"github.com/cedbossneo/mowglinext/pkg/msgs/mowgli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalSetDockingPointReq(t *testing.T) {
+	t.Run("snake_case docking_pose with floats", func(t *testing.T) {
+		body := `{"docking_pose":{"position":{"x":4.2,"y":7.7,"z":0.0},"orientation":{"x":0,"y":0,"z":0.5,"w":0.866}}}`
+		var req mowgli.SetDockingPointReq
+		err := unmarshalROSMessage[*mowgli.SetDockingPointReq](io.NopCloser(strings.NewReader(body)), &req)
+		require.NoError(t, err)
+		assert.InDelta(t, 4.2, req.DockingPose.Position.X, 1e-9)
+		assert.InDelta(t, 7.7, req.DockingPose.Position.Y, 1e-9)
+		assert.InDelta(t, 0.0, req.DockingPose.Position.Z, 1e-9)
+		assert.InDelta(t, 0.5, req.DockingPose.Orientation.Z, 1e-9)
+		assert.InDelta(t, 0.866, req.DockingPose.Orientation.W, 1e-9)
+	})
+
+	t.Run("snake_case with x=1 only", func(t *testing.T) {
+		body := `{"docking_pose":{"position":{"x":1.0,"y":0,"z":0},"orientation":{"x":0,"y":0,"z":0,"w":0}}}`
+		var req mowgli.SetDockingPointReq
+		err := unmarshalROSMessage[*mowgli.SetDockingPointReq](io.NopCloser(strings.NewReader(body)), &req)
+		require.NoError(t, err)
+		assert.InDelta(t, 1.0, req.DockingPose.Position.X, 1e-9)
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		var req mowgli.SetDockingPointReq
+		err := unmarshalROSMessage[*mowgli.SetDockingPointReq](io.NopCloser(strings.NewReader("{}")), &req)
+		require.NoError(t, err)
+		assert.Equal(t, geometry.Pose{}, req.DockingPose)
+	})
+}

--- a/gui/pkg/api/utils_test.go
+++ b/gui/pkg/api/utils_test.go
@@ -49,6 +49,22 @@ func TestUnmarshalROSMessage(t *testing.T) {
 		assert.InDelta(t, 3.14, msg.Value, 0.001)
 	})
 
+	t.Run("snake_case JSON to PascalCase struct", func(t *testing.T) {
+		// Regression: rosbridge sends snake_case keys (e.g. docking_pose,
+		// is_navigation_area). They must populate PascalCase Go fields, otherwise
+		// /map_server_node/set_docking_point gets called with a zero-valued Pose.
+		jsonBody := `{"name": "test-area", "is_navigation_area": true, "value": 2.5}`
+		reader := io.NopCloser(strings.NewReader(jsonBody))
+
+		var msg TestMsg
+		err := unmarshalROSMessage[*TestMsg](reader, &msg)
+		require.NoError(t, err)
+
+		assert.Equal(t, "test-area", msg.Name)
+		assert.True(t, msg.IsNavigationArea)
+		assert.InDelta(t, 2.5, msg.Value, 0.001)
+	})
+
 	t.Run("PascalCase JSON to PascalCase struct", func(t *testing.T) {
 		jsonBody := `{"Name": "area2", "IsNavigationArea": false, "Value": 1.0}`
 		reader := io.NopCloser(strings.NewReader(jsonBody))

--- a/gui/pkg/foxglove/cdr_write.go
+++ b/gui/pkg/foxglove/cdr_write.go
@@ -15,14 +15,18 @@ func SerializeCDR(jsonData []byte, schema *msgSchema) ([]byte, error) {
 		return nil, fmt.Errorf("cdr write: unmarshal: %w", err)
 	}
 
-	w := &cdrWriter{maxAlign: 8} // Classic XCDR1: 8-byte max alignment
-	// Encapsulation header: 0x0001 = CDR_LE (classic XCDR1 little-endian).
-	// This is ROS 2's default wire encoding for services and messages across
-	// all rmw implementations (FastDDS / CycloneDDS), so it's the most
-	// compatible choice. Previously we wrote this header with maxAlign=4 —
-	// half-XCDR2 — and rmw rejected every request with
-	// "rmw_serialize: invalid data size" because float64 landed at offset 4
-	// instead of 8. maxAlign=8 fixes float64/uint64 alignment to match.
+	// ROS 2 Kilted with the default rmw stack negotiates PLAIN_CDR2 over the
+	// wire — primitives align at most to 4 bytes regardless of the encap
+	// representation byte (this matches cdrReader's maxAlign=4 used in
+	// DeserializeCDR). With maxAlign=8 here the writer pushed leading float64
+	// fields one 8-byte slot too far, so e.g. SetDockingPoint's Pose decoded
+	// to garbage on the C++ side because position.x landed at byte 8 while
+	// rmw was reading it at byte 4.
+	w := &cdrWriter{maxAlign: 4}
+	// Encapsulation header: representation_id + options. ROS 2 publishers
+	// emit 0x0001 0x0000 (CDR_LE) regardless of the actual XCDR variant.
+	// Alignment is measured from the start of the payload (the byte AFTER
+	// this 4-byte header) — see the relative-alignment logic in cdrWriter.align.
 	w.buf = append(w.buf, 0x00, 0x01, 0x00, 0x00)
 
 	if err := w.writeMessage(msg, schema.Fields); err != nil {
@@ -40,11 +44,23 @@ func SerializeCDR(jsonData []byte, schema *msgSchema) ([]byte, error) {
 	return w.buf, nil
 }
 
+// cdrEncapHeaderLen is the size of the 4-byte CDR encapsulation header
+// (representation_id + options) that precedes the payload.
+const cdrEncapHeaderLen = 4
+
 type cdrWriter struct {
 	buf      []byte
 	maxAlign int
 }
 
+// align pads the buffer so the next write lands on an n-byte boundary
+// MEASURED FROM THE START OF THE PAYLOAD (i.e. after the 4-byte encapsulation
+// header), as required by CDR. Including the header in the modulo would push
+// every 8-byte-aligned field 4 bytes too far — fine for messages whose first
+// field is a string/uint32 (4-byte alignment is a no-op), but corrupts services
+// whose first field needs 8-byte alignment (e.g. SetDockingPoint with a Pose
+// containing leading float64s — the receiver reads at relative offset 0 and
+// gets garbage from the padding bytes).
 func (w *cdrWriter) align(n int) {
 	if n <= 1 {
 		return
@@ -52,7 +68,7 @@ func (w *cdrWriter) align(n int) {
 	if n > w.maxAlign {
 		n = w.maxAlign
 	}
-	rem := len(w.buf) % n
+	rem := (len(w.buf) - cdrEncapHeaderLen) % n
 	if rem != 0 {
 		pad := n - rem
 		for i := 0; i < pad; i++ {

--- a/gui/pkg/foxglove/cdr_write_test.go
+++ b/gui/pkg/foxglove/cdr_write_test.go
@@ -1,0 +1,99 @@
+package foxglove
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SetDockingPoint.srv request schema as foxglove_bridge advertises it: the
+// concatenated msg definitions separated by the standard "=" divider lines.
+const setDockingPointReqSchema = `geometry_msgs/Pose docking_pose
+================================================================================
+MSG: geometry_msgs/Pose
+Point position
+Quaternion orientation
+================================================================================
+MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+================================================================================
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+`
+
+// TestSerializeCDR_PoseFloat64Alignment is the regression test for the
+// /map_server_node/set_docking_point garbage-pose bug.
+//
+// On real hardware (Pi5, ROS 2 Kilted, Cyclone DDS) we observed that values
+// sent through this serializer landed at byte offset 8 in the wire payload
+// while map_server_node read them from offset 4 — yielding either zeros (when
+// the misread bytes happened to be the encap padding) or huge garbage like
+// −9.26e+58 (when the misread bytes spanned padding + actual mantissa bytes).
+//
+// The fix in this PR sets maxAlign=4 and switches align() to be relative to
+// the start of the payload, so float64 fields land where rmw expects them.
+func TestSerializeCDR_PoseFloat64Alignment(t *testing.T) {
+	schema, err := ParseSchema(setDockingPointReqSchema)
+	require.NoError(t, err)
+
+	// Picked to make alignment failures obvious: every byte of every double
+	// is non-zero so a misalignment of even one byte changes the value
+	// dramatically.
+	jsonReq := []byte(`{"docking_pose":{"position":{"x":4.2,"y":7.7,"z":1.5},"orientation":{"x":0.1,"y":0.2,"z":0.5,"w":0.866}}}`)
+
+	out, err := SerializeCDR(jsonReq, schema)
+	require.NoError(t, err)
+
+	// 4-byte encap header + 7 doubles, no padding (4-byte alignment, doubles
+	// land on 4-byte boundaries from the start of the payload).
+	require.Len(t, out, 4+7*8)
+	assert.Equal(t, []byte{0x00, 0x01, 0x00, 0x00}, out[:4], "encap header")
+
+	readDouble := func(off int) float64 {
+		return math.Float64frombits(binary.LittleEndian.Uint64(out[off : off+8]))
+	}
+
+	// position.x must be the FIRST field after the encap header, at byte 4 —
+	// not byte 8. This is the actual regression: with the old absolute-from-
+	// buffer-start alignment the writer padded 4 bytes here and the C++
+	// receiver read garbage.
+	assert.Equal(t, 4.2, readDouble(4), "position.x at byte 4")
+	assert.Equal(t, 7.7, readDouble(12), "position.y at byte 12")
+	assert.Equal(t, 1.5, readDouble(20), "position.z at byte 20")
+	assert.Equal(t, 0.1, readDouble(28), "orientation.x at byte 28")
+	assert.Equal(t, 0.2, readDouble(36), "orientation.y at byte 36")
+	assert.Equal(t, 0.5, readDouble(44), "orientation.z at byte 44")
+	assert.Equal(t, 0.866, readDouble(52), "orientation.w at byte 52")
+}
+
+// TestSerializeCDR_RoundTripsThroughReader cross-checks the writer against the
+// existing cdrReader so the two stay in lock-step.
+func TestSerializeCDR_RoundTripsThroughReader(t *testing.T) {
+	schema, err := ParseSchema(setDockingPointReqSchema)
+	require.NoError(t, err)
+
+	jsonReq := []byte(`{"docking_pose":{"position":{"x":-1.25,"y":3.5e9,"z":0},"orientation":{"x":0,"y":0,"z":0,"w":1}}}`)
+
+	wire, err := SerializeCDR(jsonReq, schema)
+	require.NoError(t, err)
+
+	decoded, err := DeserializeCDR(wire, schema)
+	require.NoError(t, err)
+
+	pose := decoded["docking_pose"].(map[string]interface{})
+	pos := pose["position"].(map[string]interface{})
+	orient := pose["orientation"].(map[string]interface{})
+
+	assert.InDelta(t, -1.25, pos["x"], 1e-12)
+	assert.InDelta(t, 3.5e9, pos["y"], 1e-3)
+	assert.InDelta(t, 0.0, pos["z"], 1e-12)
+	assert.InDelta(t, 1.0, orient["w"], 1e-12)
+}


### PR DESCRIPTION
## Summary

Two compounding bugs caused `/map_server_node/set_docking_point` to land as `(0, 0, 0)` (or, with non-zero values that exposed the second bug, as garbage like `-9.26e+58`) regardless of what the user dragged into the map editor.

### Bug 1 — `unmarshalROSMessage` dropped every snake_case key

`gui/pkg/api/utils.go` matched struct fields against incoming JSON keys by lowercasing only. PascalCase Go fields (`DockingPose`) never matched snake_case rosbridge keys (`docking_pose`), so the request struct silently stayed at its zero value before being forwarded to ROS.

**Fix:** the matcher now strips underscores too. Existing camelCase/PascalCase inputs still work; snake_case finally lands.

### Bug 2 — `SerializeCDR` misaligned float64 fields by 4 bytes

Once Bug 1 was fixed, `SetDockingPoint` started writing real values to the wire — and the receiver decoded garbage. `pkg/foxglove/cdr_write.go` used `maxAlign=8` (XCDR1) while the matching `cdrReader` and ROS 2's rmw both use PLAIN_CDR2 with `maxAlign=4`, and `align()` measured the modulo from the start of the buffer instead of the start of the payload. The first leading float64 therefore landed at byte 8 while `map_server_node` read it at byte 4.

**Fix:** `maxAlign=4` to match reader/rmw, and `align()` now measures from the start of the payload (after the 4-byte encap header).

`AddMowingArea` / `ReplaceMap` were unaffected because their first wire field is a 4-byte-aligned string — the bug only surfaced for services with a leading float64 field like `SetDockingPoint`.

## Verification

End-to-end on the Pi5 test bench (Yardforce 500, Cyclone DDS, ROS 2 Kilted, mowgli-gui `:dev` image patched in place):

| POST sent | ROS map_server_node received |
|---|---|
| (4.200, 7.700, 0.000) o=(0,0,0.5,0.866) | (4.200, 7.700, 0.000) o=(0.000, 0.000, 0.500, 0.866) ✓ |
| (-12.345, 678.900, 1.500) o=(0,0,0,1) | (-12.345, 678.900, 1.500) o=(0.000, 0.000, 0.000, 1.000) ✓ |
| (0, 0, 0) o=(0,0,0,1) | (0.000, 0.000, 0.000) o=(0.000, 0.000, 0.000, 1.000) ✓ |

GUI subscriber on `/map_server_node/docking_pose` reads back the same values; heading converted from quaternion z=0.5 / w=0.866 reads `1.047 rad` (= 60°), confirming the round-trip.

## Test plan

- [x] `go test ./pkg/api/...` — snake_case JSON populates PascalCase Go fields (`utils_test.go`, `utils_nested_test.go` for the full nested `SetDockingPointReq`)
- [x] `go test ./pkg/foxglove/...` — `TestSerializeCDR_PoseFloat64Alignment` asserts position.x lands at byte 4; `TestSerializeCDR_RoundTripsThroughReader` asserts wire compat with the reader
- [x] On Pi5: drag a real dock position via curl; verify exact coords in `mowgli-ros2` log; verify GUI subscriber reads the same values back

## Notes

- No firmware or safety-path changes; only GUI ↔ rosbridge serialization.
- Behavioural change is strictly an improvement: the system was saving zeros (or worse, garbage) regardless of input — it now saves what was sent.