### PR TITLE
fix(undock): unblock 0-cm undock — deadband, DGPS gate, BackUp distance

### DIFF
--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -281,7 +281,7 @@
                    displacement to calibrate yaw via velocity-heading
                    while staying inside typical dock-adjacent polygon
                    margins. -->
-              <BackUp backup_dist="0.5" backup_speed="0.20"/>
+              <BackUp backup_dist="1.5" backup_speed="0.20"/>
               <!-- Wait for RTK Fixed after undock. The dock often has a
                    metal canopy that attenuates GPS; once the robot is 2 m
                    out the F9P should re-acquire quickly. Timeout proceeds

--- a/ros2/src/mowgli_bringup/config/localization.yaml
+++ b/ros2/src/mowgli_bringup/config/localization.yaml
@@ -134,22 +134,19 @@ fusioncore_node:
     gnss.heading_noise: 0.1
     gnss.max_hdop: 4.0
     gnss.min_satellites: 4
-    # Accept ANY fix (plain GPS, SBAS, Fixed). Strict Fixed (4) starves
-    # the filter during RTK drops — and the F9P often drops to NavSatFix
-    # STATUS_FIX=0 (plain GPS, σ≈0.25 m) for minutes under light tree
-    # cover. At min=2 (Float+) the UKF received zero GPS updates during
-    # those intervals and position variance exploded unbounded
-    # (0.2 m → 10+ m in a few minutes). At min=1 the UKF keeps absorbing
-    # Require DGPS/SBAS or better before fusing any GPS fix. u-blox
-    # pre-RTK fixes (status=0 NavSatStatus STATUS_FIX) can anchor the UKF
-    # 3-5 m off truth and the error persists long after RTK locks because
-    # the initial position covariance grew tight around the bad first-fix
-    # location. Preflight gates mowing on RTK Fixed (fix_type 4); setting
-    # fusion's threshold at DGPS (2) keeps FusionCore idle until the
-    # receiver has at least SBAS augmentation, which empirically tracks
-    # the moment our u-blox starts reporting believable positions.
     # FusionCore enum: 0=NO_FIX, 1=GPS, 2=DGPS, 3=RTK_FLOAT, 4=RTK_FIXED.
-    gnss.min_fix_type: 2
+    # The acceptance gate appears to be strict (`fix_type > min_fix_type`),
+    # so min=2 in practice rejects DGPS as well — confirmed on a 2026-04-25
+    # field session under a metal dock canopy where the receiver dropped
+    # from RTK Float to DGPS for tens of seconds and FusionCore declared
+    # the GNSS channel STALE while every fix in the stream carried the
+    # warning `fix_type=2, min=2`. min=1 lets DGPS through (cov_floor_xy_dgps
+    # still bounds the noise at σ≈0.7 m) so the UKF stays anchored during
+    # those intermittent drops instead of running open-loop on IMU+wheels
+    # and accumulating multi-metre drift. Pre-flight still gates mowing on
+    # RTK Fixed via `WaitForGpsFix`, so allowing DGPS into fusion does not
+    # let the robot start mowing on a degraded fix.
+    gnss.min_fix_type: 1
 
     # GPS antenna offset from base_link in body frame.
     # Leaving these at 0 lets FusionCore auto-resolve the lever arm from

--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -303,9 +303,17 @@ velocity_smoother:
     max_decel: [-0.5, 0.0, -4.0]
     odom_topic: /wheel_odom
     odom_duration: 0.1
-    # Match motor deadband (PWM ~40 of 300 → 0.13 m/s). Commanded vel below
-    # this is zeroed so the motors never sit in the buzz zone.
-    deadband_velocity: [0.13, 0.0, 0.0]
+    # 0.04 m/s — small enough that nav2_behaviors' BackUp at 0.20 m/s still
+    # passes through after collision_monitor's PolygonSlow drops it to 30 %
+    # (= 0.06 m/s). The previous 0.13 m/s deadband zeroed every command in
+    # the slowdown zone around the dock, so undock would silently sit at
+    # zero velocity for the entire time_allowance and abort with code 6
+    # (DriveOnHeading goal not reached) — observed on the 2026-04-25 field
+    # session. The deadband-original justification ("match motor PWM-40
+    # buzz zone") still holds for normal driving; 0.04 m/s is well below
+    # any commanded coverage/transit speed and only matters at the edge of
+    # collision-slowdown bursts which used to break undock.
+    deadband_velocity: [0.04, 0.0, 0.0]
     velocity_timeout: 1.0
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three small config-level fixes that together turn `Start mowing` from a no-op (motors silent for the entire BackUp time-allowance, action aborted with code 6) into a clean undock. All diagnosed and verified end-to-end on the Pi5 test bench.

### Bug 1 — `velocity_smoother` deadband zeroed every undock command

Chain: `behavior_server (-0.20) → collision_monitor ×0.30 → /cmd_vel_safe (-0.06) → velocity_smoother → /cmd_vel_monitored (0.0)`. With `deadband_velocity=0.13`, every commanded velocity below 0.13 m/s was zeroed. Since the dock itself triggers `PolygonSlow` (lidar sees dock structure right behind robot during BackUp), the slowdown stayed active for the entire undock attempt — and -0.06 m/s < 0.13 m/s deadband → motors stayed silent.

**Fix:** `deadband_velocity: 0.13 → 0.04 m/s`. Still well above the PWM-buzz zone for any real driving speed.

### Bug 2 — DGPS fixes silently rejected, fusion drifts open-loop

`fix_type > min_fix_type` is a strict comparison, so `min=2` rejects DGPS (`fix_type=2`) too. With every fix rejected for tens of seconds at a time under the dock canopy, the UKF ran open-loop on IMU+wheels, drifted multi-metres while stationary, and BoundaryGuard then fired before the next undock could even move because fusion thought the robot was outside the polygon.

**Fix:** `gnss.min_fix_type: 2 → 1`. Pre-flight still gates mowing on RTK Fixed via `WaitForGpsFix(min_fix_type=4)`.

### Bug 3 — BackUp undock distance hardcoded to 0.5 m

The BT XML's main UndockSequence (`line 284`) used 0.5 m, but the GUI undock setting and two adjacent recovery branches (lines 363, 411) already used 1.5 m. Operator saw "1.5 m" in settings but only got 0.5 m of motion.

**Fix:** Align line 284 with the rest at 1.5 m. The Mowgli BackUp BT-node wrapper auto-derives `time_allowance = dist/speed × 3` (= 22.5 s for 1.5 m at 0.20 m/s), so no time_allowance attribute is needed and adding one would crash BehaviorTree.CPP at load time (the wrapper does not declare a `time_allowance` port).

## Verification on Pi5 (Yardforce 500, Cyclone DDS, ROS 2 Kilted)

| State | Commanded | Physical |
|---|---|---|
| Before any fix | n/a | **0 cm** (motors silent the whole time) |
| Deadband fix only | 0.5 m | 0.45 m, action aborts at time_allowance |
| Deadband + 1.5 m distance | 1.5 m | **1.05 m**, mower clears the dock visibly |
| All three fixes | 1.5 m | + fusioncore stops declaring GNSS STALE the moment receiver drops to DGPS under canopy |

## Test plan

- [x] velocity_smoother deadband: confirmed `/cmd_vel_safe = -0.06` now reaches `/cmd_vel_monitored = -0.06` (was 0)
- [x] min_fix_type: warning text changed from `min=2` → `min=1`; DGPS fixes accepted into the UKF
- [x] BackUp distance: log shows `BackUp: reversing 1.50m at 0.20 m/s` (was `0.50m`)
- [x] On-Pi end-to-end: `Start mowing` → mower leaves the dock by 1.05 m physically

## Out of scope (follow-up PRs)

- Left/right encoder asymmetry that made the 1.05 m undock curve (left ~94 % more ticks than right) — likely PWM-deadband mismatch, needs per-motor calibration.
- BoundaryGuard self-lock: `SoftBoundaryHandler` fires `StopMoving` on `/cmd_vel_emergency` at priority 100 while its own `NavigateInsideBoundary` recovery runs on `/cmd_vel_nav` at priority 10 → recovery starves itself.
- Fusion's Mahalanobis gate rejection of clean DGPS fixes (`hdop=0.3` rejected) — needs source-level tweak in fusioncore (out of repo).