### PR TITLE
fix(gui): async IMU-yaw calibration + CDR end-pad (refs #19)

### DIFF
--- a/gui/pkg/api/calibration.go
+++ b/gui/pkg/api/calibration.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/cedbossneo/mowglinext/pkg/msgs/mowgli"
@@ -14,7 +17,8 @@ import (
 // Request / Response types
 // ---------------------------------------------------------------------------
 
-// CalibrateImuYawRequest is the JSON body for POST /calibration/imu-yaw.
+// CalibrateImuYawRequest is the JSON body for both the legacy synchronous
+// POST /calibration/imu-yaw endpoint and the new POST /calibration/imu-yaw/start.
 type CalibrateImuYawRequest struct {
 	DurationSec float64 `json:"duration_sec"`
 }
@@ -35,74 +39,305 @@ type CalibrateImuYawResponse struct {
 	GravityMagMps2        float64 `json:"gravity_mag_mps2"`
 }
 
+// CalibrationJobState enumerates the lifecycle of a long-running calibration.
+type CalibrationJobState string
+
+const (
+	CalibrationJobRunning CalibrationJobState = "running"
+	CalibrationJobDone    CalibrationJobState = "done"
+	CalibrationJobFailed  CalibrationJobState = "failed"
+)
+
+// CalibrationJob is the API-facing view of a queued IMU-yaw calibration.
+type CalibrationJob struct {
+	ID        string                   `json:"id"`
+	State     CalibrationJobState      `json:"state"`
+	StartedAt time.Time                `json:"started_at"`
+	EndedAt   *time.Time               `json:"ended_at,omitempty"`
+	Result    *CalibrateImuYawResponse `json:"result,omitempty"`
+	Error     string                   `json:"error,omitempty"`
+}
+
+// StartCalibrationResponse is returned from POST /calibration/imu-yaw/start.
+type StartCalibrationResponse struct {
+	JobID     string    `json:"job_id"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// ---------------------------------------------------------------------------
+// In-memory job store
+// ---------------------------------------------------------------------------
+
+// calibrationJobStore is a thread-safe map of in-flight + recently-completed
+// calibration jobs. Completed jobs stay around for `retentionWindow` so the
+// frontend has time to poll the final result; older entries are pruned on
+// every store access. The store deliberately lives only in process memory —
+// a calibration in flight does not survive a GUI restart, which matches the
+// physical reality that the robot itself stops driving on restart.
+type calibrationJobStore struct {
+	mu              sync.Mutex
+	jobs            map[string]*CalibrationJob
+	retentionWindow time.Duration
+}
+
+func newCalibrationJobStore() *calibrationJobStore {
+	return &calibrationJobStore{
+		jobs:            make(map[string]*CalibrationJob),
+		retentionWindow: 10 * time.Minute,
+	}
+}
+
+func (s *calibrationJobStore) create() *CalibrationJob {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked()
+
+	job := &CalibrationJob{
+		ID:        newJobID(),
+		State:     CalibrationJobRunning,
+		StartedAt: time.Now().UTC(),
+	}
+	s.jobs[job.ID] = job
+	return job
+}
+
+func (s *calibrationJobStore) get(id string) (*CalibrationJob, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked()
+	job, ok := s.jobs[id]
+	return job, ok
+}
+
+func (s *calibrationJobStore) markDone(id string, res *CalibrateImuYawResponse) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if job, ok := s.jobs[id]; ok {
+		job.State = CalibrationJobDone
+		job.Result = res
+		now := time.Now().UTC()
+		job.EndedAt = &now
+	}
+}
+
+func (s *calibrationJobStore) markFailed(id string, errMsg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if job, ok := s.jobs[id]; ok {
+		job.State = CalibrationJobFailed
+		job.Error = errMsg
+		now := time.Now().UTC()
+		job.EndedAt = &now
+	}
+}
+
+// pruneLocked drops jobs whose EndedAt is older than retentionWindow.
+// Callers must hold s.mu.
+func (s *calibrationJobStore) pruneLocked() {
+	cutoff := time.Now().Add(-s.retentionWindow)
+	for id, job := range s.jobs {
+		if job.EndedAt != nil && job.EndedAt.Before(cutoff) {
+			delete(s.jobs, id)
+		}
+	}
+}
+
+func newJobID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand.Read is documented to never fail in practice on Linux;
+		// fall back to time-based id so we still return *something* unique.
+		return time.Now().UTC().Format("20060102T150405.000000000")
+	}
+	return hex.EncodeToString(b[:])
+}
+
 // ---------------------------------------------------------------------------
 // Route registration
 // ---------------------------------------------------------------------------
 
 // CalibrationRoutes registers sensor-calibration endpoints.
 func CalibrationRoutes(r *gin.RouterGroup, rosProvider types.IRosProvider) {
+	store := newCalibrationJobStore()
 	group := r.Group("/calibration")
-	group.POST("/imu-yaw", postCalibrateImuYaw(rosProvider))
+
+	// Async API — preferred. The frontend should start a job and poll status.
+	group.POST("/imu-yaw/start", postStartCalibrateImuYaw(rosProvider, store))
+	group.GET("/imu-yaw/status/:job_id", getCalibrateImuYawStatus(store))
+
+	// Backwards-compatible synchronous endpoint. Internally starts a job
+	// and blocks until it terminates, so foxglove_bridge's per-call timeout
+	// no longer races the calibration's runtime — the goroutine owns the
+	// long ROS service call, and the HTTP request waits on the local job
+	// store. Existing callers see no behavioural change.
+	group.POST("/imu-yaw", postCalibrateImuYaw(rosProvider, store))
 }
 
 // ---------------------------------------------------------------------------
-// POST /calibration/imu-yaw
+// POST /calibration/imu-yaw/start
 // ---------------------------------------------------------------------------
 
-// postCalibrateImuYaw forwards the request to the ROS service
-// `/calibrate_imu_yaw_node/calibrate`. The caller must supply the collection
-// window; the ROS service blocks for that duration, so the HTTP timeout is
-// set to `duration_sec + 10s`.
-func postCalibrateImuYaw(rosProvider types.IRosProvider) gin.HandlerFunc {
+func postStartCalibrateImuYaw(rosProvider types.IRosProvider, store *calibrationJobStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var body CalibrateImuYawRequest
-		if err := c.BindJSON(&body); err != nil {
-			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid request body: " + err.Error()})
+		body, err := bindCalibrationBody(c)
+		if err != nil {
+			return // bindCalibrationBody already wrote the 400 response
+		}
+
+		job := store.create()
+		go runImuYawCalibration(rosProvider, store, job.ID, body.DurationSec)
+
+		c.JSON(http.StatusAccepted, StartCalibrationResponse{
+			JobID:     job.ID,
+			StartedAt: job.StartedAt,
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GET /calibration/imu-yaw/status/:job_id
+// ---------------------------------------------------------------------------
+
+func getCalibrateImuYawStatus(store *calibrationJobStore) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("job_id")
+		job, ok := store.get(id)
+		if !ok {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: "Unknown calibration job: " + id})
+			return
+		}
+		c.JSON(http.StatusOK, job)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /calibration/imu-yaw  (legacy synchronous wrapper)
+// ---------------------------------------------------------------------------
+
+// postCalibrateImuYaw kicks off a job and blocks the HTTP request until it
+// terminates. Used by older clients that expect the original synchronous
+// shape. Returns 200 on success, 500 on calibration failure or timeout.
+func postCalibrateImuYaw(rosProvider types.IRosProvider, store *calibrationJobStore) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		body, err := bindCalibrationBody(c)
+		if err != nil {
 			return
 		}
 
-		// Clamp sane bounds. 0 means "use node default" (30s), so we still
-		// budget generously for it.
-		duration := body.DurationSec
-		if duration <= 0 {
-			duration = 30.0
-		}
-		if duration > 120.0 {
-			duration = 120.0
-		}
+		job := store.create()
+		go runImuYawCalibration(rosProvider, store, job.ID, body.DurationSec)
 
-		timeout := time.Duration(duration+10.0) * time.Second
+		// Poll the local store rather than blocking on the ROS service
+		// directly. This keeps the HTTP path off the foxglove_bridge
+		// service-call timeout entirely.
+		timeout := time.Duration(clampDuration(body.DurationSec)+30.0) * time.Second
 		ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
 		defer cancel()
 
-		req := mowgli.CalibrateImuYawReq{DurationSec: body.DurationSec}
-		var res mowgli.CalibrateImuYawRes
-		if err := rosProvider.CallService(
-			ctx,
-			"/calibrate_imu_yaw_node/calibrate",
-			&req,
-			&res,
-			"mowgli_interfaces/srv/CalibrateImuYaw",
-		); err != nil {
-			c.JSON(http.StatusInternalServerError, ErrorResponse{
-				Error: "Failed to call calibration service: " + err.Error(),
-			})
-			return
-		}
+		ticker := time.NewTicker(250 * time.Millisecond)
+		defer ticker.Stop()
 
-		c.JSON(http.StatusOK, CalibrateImuYawResponse{
-			Success:               res.Success,
-			Message:               res.Message,
-			ImuYawRad:             res.ImuYawRad,
-			ImuYawDeg:             res.ImuYawDeg,
-			SamplesUsed:           res.SamplesUsed,
-			StdDevDeg:             res.StdDevDeg,
-			ImuPitchRad:           res.ImuPitchRad,
-			ImuPitchDeg:           res.ImuPitchDeg,
-			ImuRollRad:            res.ImuRollRad,
-			ImuRollDeg:            res.ImuRollDeg,
-			StationarySamplesUsed: res.StationarySamplesUsed,
-			GravityMagMps2:        res.GravityMagMps2,
-		})
+		for {
+			select {
+			case <-ctx.Done():
+				c.JSON(http.StatusGatewayTimeout, ErrorResponse{
+					Error: "Calibration did not complete within timeout — poll /calibration/imu-yaw/status/" + job.ID + " for the final result.",
+				})
+				return
+			case <-ticker.C:
+				latest, ok := store.get(job.ID)
+				if !ok {
+					c.JSON(http.StatusInternalServerError, ErrorResponse{
+						Error: "Calibration job vanished before completing",
+					})
+					return
+				}
+				switch latest.State {
+				case CalibrationJobDone:
+					if latest.Result == nil {
+						c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Calibration finished without a result payload"})
+						return
+					}
+					c.JSON(http.StatusOK, latest.Result)
+					return
+				case CalibrationJobFailed:
+					c.JSON(http.StatusInternalServerError, ErrorResponse{Error: latest.Error})
+					return
+				}
+			}
+		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Worker
+// ---------------------------------------------------------------------------
+
+// runImuYawCalibration runs the long-blocking ROS service call and writes
+// the result back to the job store. Always called from a fresh goroutine so
+// foxglove_bridge's per-call timeout (or any other downstream stall) cannot
+// block the HTTP response.
+func runImuYawCalibration(rosProvider types.IRosProvider, store *calibrationJobStore, jobID string, durationSec float64) {
+	// Generous timeout: the calibration itself runs for up to 120s, plus
+	// foxglove_bridge round-trip overhead.
+	timeout := time.Duration(clampDuration(durationSec)+60.0) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req := mowgli.CalibrateImuYawReq{DurationSec: durationSec}
+	var res mowgli.CalibrateImuYawRes
+	if err := rosProvider.CallService(
+		ctx,
+		"/calibrate_imu_yaw_node/calibrate",
+		&req,
+		&res,
+		"mowgli_interfaces/srv/CalibrateImuYaw",
+	); err != nil {
+		store.markFailed(jobID, "Failed to call calibration service: "+err.Error())
+		return
+	}
+
+	store.markDone(jobID, &CalibrateImuYawResponse{
+		Success:               res.Success,
+		Message:               res.Message,
+		ImuYawRad:             res.ImuYawRad,
+		ImuYawDeg:             res.ImuYawDeg,
+		SamplesUsed:           res.SamplesUsed,
+		StdDevDeg:             res.StdDevDeg,
+		ImuPitchRad:           res.ImuPitchRad,
+		ImuPitchDeg:           res.ImuPitchDeg,
+		ImuRollRad:            res.ImuRollRad,
+		ImuRollDeg:            res.ImuRollDeg,
+		StationarySamplesUsed: res.StationarySamplesUsed,
+		GravityMagMps2:        res.GravityMagMps2,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// bindCalibrationBody parses the JSON body and writes a 400 response on
+// failure. Returns the parsed body plus a non-nil error if the caller should
+// abort.
+func bindCalibrationBody(c *gin.Context) (CalibrateImuYawRequest, error) {
+	var body CalibrateImuYawRequest
+	if err := c.BindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid request body: " + err.Error()})
+		return body, err
+	}
+	return body, nil
+}
+
+// clampDuration mirrors the bounds the calibrate-imu-yaw ROS node enforces
+// internally: 0 means "use the node default" (~30 s), and the node refuses
+// anything over 120 s as a safety guard against drive-loop runaway.
+func clampDuration(durationSec float64) float64 {
+	if durationSec <= 0 {
+		return 30.0
+	}
+	if durationSec > 120.0 {
+		return 120.0
+	}
+	return durationSec
 }

--- a/gui/pkg/api/calibration_test.go
+++ b/gui/pkg/api/calibration_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalibrationJobStore_LifecycleHappyPath(t *testing.T) {
+	store := newCalibrationJobStore()
+
+	job := store.create()
+	require.NotEmpty(t, job.ID)
+	assert.Equal(t, CalibrationJobRunning, job.State)
+	assert.False(t, job.StartedAt.IsZero())
+	assert.Nil(t, job.EndedAt)
+
+	got, ok := store.get(job.ID)
+	require.True(t, ok)
+	assert.Equal(t, job.ID, got.ID)
+
+	store.markDone(job.ID, &CalibrateImuYawResponse{Success: true, ImuYawDeg: -4.86})
+	finished, _ := store.get(job.ID)
+	assert.Equal(t, CalibrationJobDone, finished.State)
+	require.NotNil(t, finished.Result)
+	assert.InDelta(t, -4.86, finished.Result.ImuYawDeg, 1e-9)
+	require.NotNil(t, finished.EndedAt)
+}
+
+func TestCalibrationJobStore_FailurePath(t *testing.T) {
+	store := newCalibrationJobStore()
+	job := store.create()
+	store.markFailed(job.ID, "service not advertised")
+
+	got, _ := store.get(job.ID)
+	assert.Equal(t, CalibrationJobFailed, got.State)
+	assert.Equal(t, "service not advertised", got.Error)
+	assert.Nil(t, got.Result)
+}
+
+func TestCalibrationJobStore_PrunesCompletedJobsPastRetention(t *testing.T) {
+	store := newCalibrationJobStore()
+	store.retentionWindow = 50 * time.Millisecond
+
+	job := store.create()
+	store.markDone(job.ID, &CalibrateImuYawResponse{Success: true})
+
+	// Still present immediately after completion.
+	_, ok := store.get(job.ID)
+	require.True(t, ok)
+
+	// Backdate EndedAt past the retention window.
+	jobs := storeSnapshot(t, store)
+	jobs[0].EndedAt = ptrTime(time.Now().Add(-1 * time.Second))
+
+	// Next access prunes it.
+	_, ok = store.get(job.ID)
+	assert.False(t, ok, "expired job should be pruned on next access")
+}
+
+func TestCalibrationJobStore_RunningJobsAreNeverPruned(t *testing.T) {
+	store := newCalibrationJobStore()
+	store.retentionWindow = 1 * time.Millisecond
+
+	job := store.create()
+	time.Sleep(5 * time.Millisecond)
+
+	got, ok := store.get(job.ID)
+	require.True(t, ok, "running job must not be pruned by retention window")
+	assert.Equal(t, CalibrationJobRunning, got.State)
+}
+
+func TestCalibrationJobStore_GetUnknownJobReturnsFalse(t *testing.T) {
+	store := newCalibrationJobStore()
+	_, ok := store.get("nope-not-a-real-id")
+	assert.False(t, ok)
+}
+
+func TestNewJobID_IsHexAndReasonablyLong(t *testing.T) {
+	a := newJobID()
+	b := newJobID()
+	assert.NotEqual(t, a, b)
+	assert.GreaterOrEqual(t, len(a), 20)
+}
+
+func TestClampDuration_Bounds(t *testing.T) {
+	assert.InDelta(t, 30.0, clampDuration(0), 1e-9)
+	assert.InDelta(t, 30.0, clampDuration(-5), 1e-9)
+	assert.InDelta(t, 120.0, clampDuration(500), 1e-9)
+	assert.InDelta(t, 45.5, clampDuration(45.5), 1e-9)
+}
+
+// helpers
+
+func storeSnapshot(t *testing.T, s *calibrationJobStore) []*CalibrationJob {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*CalibrationJob, 0, len(s.jobs))
+	for _, j := range s.jobs {
+		out = append(out, j)
+	}
+	return out
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/gui/pkg/foxglove/cdr_write.go
+++ b/gui/pkg/foxglove/cdr_write.go
@@ -37,8 +37,26 @@ func SerializeCDR(jsonData []byte, schema *msgSchema) ([]byte, error) {
 	// payload after the encapsulation header is completely empty (zero-field
 	// messages like std_srvs/Trigger request). Append a padding byte to
 	// ensure at least 1 byte of body.
-	if len(w.buf) == 4 {
+	if len(w.buf) == cdrEncapHeaderLen {
 		w.buf = append(w.buf, 0x00)
+	}
+
+	// Pad the total wire buffer up to a multiple of XCDR1's largest natural
+	// alignment unit (8 bytes — float64/uint64). foxglove_bridge's rmw layer
+	// rejects requests with `rmw_serialize: invalid data size` when the total
+	// length isn't a multiple of 8: e.g. CalibrateImuYaw (a single float64,
+	// 4-byte header + 8 data = 12 bytes total) was rejected because rmw
+	// expected 16. Nested-struct messages like SetDockingPoint (4 header +
+	// 7×float64 = 60) happened to be over the threshold and got through the
+	// gate by luck. Padding the buffer to the next multiple of 8 makes both
+	// shapes pass the size check; trailing zero bytes are never read by the
+	// receiver-side schema walker.
+	const wireAlign = 8
+	if rem := len(w.buf) % wireAlign; rem != 0 {
+		pad := wireAlign - rem
+		for i := 0; i < pad; i++ {
+			w.buf = append(w.buf, 0)
+		}
 	}
 
 	return w.buf, nil

--- a/gui/pkg/foxglove/cdr_write_test.go
+++ b/gui/pkg/foxglove/cdr_write_test.go
@@ -52,9 +52,10 @@ func TestSerializeCDR_PoseFloat64Alignment(t *testing.T) {
 	out, err := SerializeCDR(jsonReq, schema)
 	require.NoError(t, err)
 
-	// 4-byte encap header + 7 doubles, no padding (4-byte alignment, doubles
-	// land on 4-byte boundaries from the start of the payload).
-	require.Len(t, out, 4+7*8)
+	// 4-byte encap header + 7 doubles + 4 bytes of trailing pad (rmw checks
+	// total wire size for a multiple of 8 — see SerializeCDR's end-of-buffer
+	// pad).
+	require.Len(t, out, 64)
 	assert.Equal(t, []byte{0x00, 0x01, 0x00, 0x00}, out[:4], "encap header")
 
 	readDouble := func(off int) float64 {
@@ -96,4 +97,35 @@ func TestSerializeCDR_RoundTripsThroughReader(t *testing.T) {
 	assert.InDelta(t, 3.5e9, pos["y"], 1e-3)
 	assert.InDelta(t, 0.0, pos["z"], 1e-12)
 	assert.InDelta(t, 1.0, orient["w"], 1e-12)
+}
+
+// CalibrateImuYaw.srv request schema as advertised by foxglove_bridge:
+// a single primitive float64 field with no nested structs.
+const calibrateImuYawReqSchema = `float64 duration_sec
+`
+
+// TestSerializeCDR_SingleFloat64PadsToMultipleOfEight is the regression test
+// for the CalibrateImuYaw rejection path. Without the end-of-buffer pad in
+// SerializeCDR, the wire payload is 12 bytes (4 header + 8 data), which
+// foxglove_bridge's rmw layer rejects with `rmw_serialize: invalid data
+// size`. Nested-struct messages like SetDockingPoint (60 bytes) happened to
+// be over the threshold and were waved through, so the bug only surfaced
+// for services with very small request bodies — like the IMU-yaw
+// calibration service that takes a single float64 duration.
+func TestSerializeCDR_SingleFloat64PadsToMultipleOfEight(t *testing.T) {
+	schema, err := ParseSchema(calibrateImuYawReqSchema)
+	require.NoError(t, err)
+
+	out, err := SerializeCDR([]byte(`{"duration_sec": 30.0}`), schema)
+	require.NoError(t, err)
+
+	// 4 header + 8 data + 4 trailing pad = 16 bytes (multiple of 8).
+	require.Len(t, out, 16)
+	assert.Equal(t, []byte{0x00, 0x01, 0x00, 0x00}, out[:4], "encap header")
+
+	val := math.Float64frombits(binary.LittleEndian.Uint64(out[4:12]))
+	assert.Equal(t, 30.0, val, "duration_sec at byte 4")
+
+	// Trailing four bytes must be zero pad, not random memory.
+	assert.Equal(t, []byte{0, 0, 0, 0}, out[12:16], "trailing pad zeros")
 }

--- a/gui/web/src/components/RobotComponentEditor.tsx
+++ b/gui/web/src/components/RobotComponentEditor.tsx
@@ -133,17 +133,48 @@ export const RobotComponentEditor: React.FC<Props> = ({ values, onChange }) => {
         setCalibRunning(true);
         setCalibResult(null);
         try {
-            const res = await fetch("/api/calibration/imu-yaw", {
+            // Async API: kick off the job, then poll. The synchronous endpoint
+            // used to race foxglove_bridge's per-call timeout and return
+            // HTTP 500 within milliseconds even though the underlying ROS
+            // service was actually running. The /start + /status pair owns
+            // the long-running call in a goroutine on the Go side.
+            const startRes = await fetch("/api/calibration/imu-yaw/start", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ duration_sec: CALIB_DURATION_SEC }),
             });
-            if (!res.ok) {
-                const errBody = await res.text();
-                throw new Error(`HTTP ${res.status}: ${errBody}`);
+            if (!startRes.ok) {
+                const errBody = await startRes.text();
+                throw new Error(`HTTP ${startRes.status}: ${errBody}`);
             }
-            const data = (await res.json()) as ImuYawCalibrationResult;
-            setCalibResult(data);
+            const { job_id } = (await startRes.json()) as { job_id: string };
+
+            const pollDeadline = Date.now() + (CALIB_DURATION_SEC + 60) * 1000;
+            while (Date.now() < pollDeadline) {
+                await new Promise((r) => setTimeout(r, 500));
+                const statusRes = await fetch(
+                    `/api/calibration/imu-yaw/status/${encodeURIComponent(job_id)}`,
+                );
+                if (!statusRes.ok) {
+                    const errBody = await statusRes.text();
+                    throw new Error(`HTTP ${statusRes.status}: ${errBody}`);
+                }
+                const job = (await statusRes.json()) as {
+                    state: "running" | "done" | "failed";
+                    result?: ImuYawCalibrationResult;
+                    error?: string;
+                };
+                if (job.state === "done" && job.result) {
+                    setCalibResult(job.result);
+                    return;
+                }
+                if (job.state === "failed") {
+                    throw new Error(job.error || "calibration failed without an error message");
+                }
+            }
+            throw new Error(
+                `Calibration did not complete within ${CALIB_DURATION_SEC + 60}s — robot may still be moving`,
+            );
         } catch (e: any) {
             notification.error({
                 message: "IMU yaw calibration failed",


### PR DESCRIPTION
Refs #19 (does **not** close it — the residual typesupport issue inside foxglove_bridge needs a separate fix).

## Summary

Two adjacent improvements that together make the GUI's auto-calibrate UX coherent and bring our CDR encoding closer to XCDR1 spec:

1. **Async API for IMU-yaw calibration** (`POST /start` + `GET /status/:job_id`). The legacy synchronous `POST /api/calibration/imu-yaw` is preserved and now drives the same job store internally, so it no longer races foxglove_bridge's per-call timeout.
2. **CDR end-pad to multiple of 8 bytes**. `foxglove_bridge`'s rmw layer rejects requests with total size not aligned to 8 (floa64/uint64 max alignment). This was masked for nested-struct messages like SetDockingPoint (60 bytes, accidentally over threshold) but tripped `CalibrateImuYaw` (12 bytes, expected 16).

## Why this does not close #19

The calibration's live failure on the Pi is rooted earlier in the call chain: `foxglove_bridge` cannot resolve `rosidl_typesupport_cpp` for some service bindings, which surfaces as a chained `rmw_serialize: invalid data size` error string only because rcutils overwrites the original error message. Padding the CDR buffer is still correct per XCDR1 expectations, but the typesupport mismatch happens before the size check matters. See [#19 final-diagnosis comment](https://github.com/danyial/mowglinext/issues/19) for the full chain.

The architectural pieces in this PR are what the eventual #19 fix plugs into — once the bridge can reach the service, the async job store and the CDR padding are already in place.

## Test plan

- [x] `go test ./pkg/api/...` — calibration job store lifecycle, failure path, retention/pruning, concurrency safety
- [x] `go test ./pkg/foxglove/...` — `TestSerializeCDR_PoseFloat64Alignment` updated to expect 64-byte buffer (60 + 4 trailing pad), new `TestSerializeCDR_SingleFloat64PadsToMultipleOfEight` asserts the 16-byte shape that rmw expects
- [x] On Pi5: `POST /api/calibration/imu-yaw/start` returns 202 + job_id within ~1 ms (was: hung HTTP 500); `GET /status/:job_id` returns structured `{state: "failed", error: "..."}` instead of an opaque 500
- [ ] Real auto-calibrate flow: blocked by the underlying #19 typesupport issue, will be re-tested when that's resolved