### PR TITLE
fix(install): wrap docker compose calls with sg trampoline (closes #27)

### DIFF
--- a/install/lib/compose.sh
+++ b/install/lib/compose.sh
@@ -149,13 +149,13 @@ run_compose_stack() {
   info "Using env file: $INSTALL_DIR/.env"
 
   info "Pulling selected images..."
-  docker compose --env-file "$INSTALL_DIR/.env" pull
+  docker_run docker compose --env-file "$INSTALL_DIR/.env" pull
 
   echo ""
   info "Starting stack..."
-  docker compose --env-file "$INSTALL_DIR/.env" up -d
+  docker_run docker compose --env-file "$INSTALL_DIR/.env" up -d
 
   echo ""
   info "Current containers:"
-  docker compose --env-file "$INSTALL_DIR/.env" ps
+  docker_run docker compose --env-file "$INSTALL_DIR/.env" ps
 }

--- a/install/lib/docker.sh
+++ b/install/lib/docker.sh
@@ -24,3 +24,22 @@ install_docker() {
     warn "Added $USER to docker group — log out/in for it to take effect"
   fi
 }
+
+# Run a command with the docker group active.
+#
+# On a fresh install, `usermod -aG docker` (above) won't take effect in the
+# current shell — the new group membership is only picked up at next login.
+# Running `docker ...` directly then fails with "permission denied while
+# trying to connect to the docker API". We work around this by trampolining
+# through `sg docker -c …` when the socket is unreachable but the user is
+# already in the group. Re-runs (where the user has logged in again) take
+# the fast path and call the command directly. See issue #27.
+docker_run() {
+  if docker info >/dev/null 2>&1; then
+    "$@"
+  elif groups "$USER" 2>/dev/null | grep -qw docker; then
+    sg docker -c "$(printf '%q ' "$@")"
+  else
+    "$@"
+  fi
+}


### PR DESCRIPTION
## Summary

- Add `docker_run` helper in `install/lib/docker.sh` that re-enters the docker group via `sg docker -c …` when the socket isn't reachable but the user is already in the group (fresh-install case)
- Wrap the three `docker compose` callsites in `run_compose_stack` (pull, up, ps) with the helper

Fixes the "fresh install needs a reboot to finish" bug reported in #27.

## Why

On a fresh install (`./install/mowglinext.sh` on a system where the user has never used Docker), `usermod -aG docker` runs but the new group membership only takes effect on the next login. The script then immediately calls `docker compose pull` in the same shell, which fails with:

```
unable to get image 'eclipse-mosquitto:latest': permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
```

The user currently has to reboot and re-run the installer. With this patch, the helper detects the situation and trampolines through `sg docker -c "<cmd>"` so the same script execution can finish.

Re-runs (after a real login) detect that `docker info` already works and take the fast path — no `sg` wrapping, no behavior change.

## Test plan

- [ ] **Pi5 fresh-install reproduction**: requires wiping the test bench, so not run during PR creation. Lowest-disruption smoke check on existing Pi5: temporarily drop docker group from a throwaway user with `gpasswd -d <user> docker`, run `install/mowglinext.sh` as that user, confirm pull/up succeed without reboot.
- [x] `bash -n install/lib/docker.sh install/lib/compose.sh` — syntax OK
- [x] Diff review: only the 3 install-time `docker compose` callsites in `run_compose_stack` are wrapped; `config.sh:579` (post-install reconfigure restart) is intentionally unchanged because the user has logged in again by then.
- [ ] First real validation will land on the next fresh Pi flash.

## Notes

- `sg` ships in the `shadow` package on every Debian/Raspberry Pi OS install — no extra dep.
- `printf '%q ' "$@"` produces shell-safe quoting for the command passed to `sg -c`.
- The helper falls through to a direct call if neither path applies, so the original error surfaces unchanged in unforeseen edge cases.