### PR TITLE
fix(gps-nmea): zero GGA geoid separation in differentially-corrected modes (UM980 doubled-geoid bug)

### DIFF
--- a/sensors/gps-nmea/nmea_serial_bridge.py
+++ b/sensors/gps-nmea/nmea_serial_bridge.py
@@ -108,6 +108,29 @@ class NmeaSerialBridge(Node):
         except ValueError:
             return None
 
+    @staticmethod
+    def _zero_gga_geoid_separation(line: str) -> str:
+        # Workaround for UM980 (and other Unicore N4 receivers) RTK behaviour:
+        # in RTK Float / Fixed modes the receiver puts the rover's HAE in field 9
+        # (the "MSL altitude" slot) but still emits the geoid separation in
+        # field 11. nmea_navsat_driver naively adds them, producing
+        # HAE + geoid_sep = a doubled geoid offset (~+47 m in southern Germany).
+        # Zeroing field 11 keeps the driver's MSL+0 = HAE arithmetic correct.
+        # Caller must already have decided this transform should run (i.e. the
+        # GGA quality is 4 or 5) — we only do the field rewrite + checksum here.
+        body, _, _ = line.partition("*")
+        parts = body.split(",")
+        # Full GGA: $G[NP]GGA,utc,lat,N/S,lon,E/W,quality,sats,hdop,
+        #          alt,M,geoid_sep,M,age,station
+        if len(parts) < 13:
+            return line
+        parts[11] = "0.0"
+        new_body = ",".join(parts)
+        checksum = 0
+        for c in new_body[1:]:  # XOR everything between '$' (excl) and '*' (excl)
+            checksum ^= ord(c)
+        return f"{new_body}*{checksum:02X}"
+
     def _on_fix_raw(self, msg: NavSatFix) -> None:
         with self._quality_lock:
             q = self._last_quality
@@ -128,11 +151,15 @@ class NmeaSerialBridge(Node):
                         line = raw.decode("ascii", errors="replace").strip()
                         if not line.startswith("$"):
                             continue
-                        # Track GGA quality for the NavSatFix republisher.
+                        # Track GGA quality for the NavSatFix republisher and,
+                        # in RTK modes, normalise away the doubled-geoid bug
+                        # before downstream consumers see the sentence.
                         q = self._gga_quality(line)
                         if q is not None:
                             with self._quality_lock:
                                 self._last_quality = q
+                            if q >= 4:
+                                line = self._zero_gga_geoid_separation(line)
                         msg = Sentence()
                         msg.header.stamp = self.get_clock().now().to_msg()
                         msg.header.frame_id = self._frame_id

--- a/sensors/gps-nmea/nmea_serial_bridge.py
+++ b/sensors/gps-nmea/nmea_serial_bridge.py
@@ -110,14 +110,17 @@ class NmeaSerialBridge(Node):
 
     @staticmethod
     def _zero_gga_geoid_separation(line: str) -> str:
-        # Workaround for UM980 (and other Unicore N4 receivers) RTK behaviour:
-        # in RTK Float / Fixed modes the receiver puts the rover's HAE in field 9
-        # (the "MSL altitude" slot) but still emits the geoid separation in
-        # field 11. nmea_navsat_driver naively adds them, producing
-        # HAE + geoid_sep = a doubled geoid offset (~+47 m in southern Germany).
-        # Zeroing field 11 keeps the driver's MSL+0 = HAE arithmetic correct.
-        # Caller must already have decided this transform should run (i.e. the
-        # GGA quality is 4 or 5) — we only do the field rewrite + checksum here.
+        # Workaround for UM980 (and other Unicore N4 receivers) when any
+        # base-station corrections are active: in DGPS, RTK Float and RTK
+        # Fixed modes (GGA quality 2, 3, 4, 5) the receiver puts the rover's
+        # HAE in field 9 (the "MSL altitude" slot) but still emits the geoid
+        # separation in field 11. nmea_navsat_driver naively adds them,
+        # producing HAE + geoid_sep = a doubled geoid offset (~+47 m in
+        # southern Germany). Zeroing field 11 keeps the driver's MSL+0 = HAE
+        # arithmetic correct. Pure SPP (q=1) is spec-compliant — field 9 is
+        # actual MSL — so it must NOT go through this transform.
+        # Caller must already have gated on q in {2, 3, 4, 5} — we only do
+        # the field rewrite + checksum here.
         body, _, _ = line.partition("*")
         parts = body.split(",")
         # Full GGA: $G[NP]GGA,utc,lat,N/S,lon,E/W,quality,sats,hdop,
@@ -152,13 +155,14 @@ class NmeaSerialBridge(Node):
                         if not line.startswith("$"):
                             continue
                         # Track GGA quality for the NavSatFix republisher and,
-                        # in RTK modes, normalise away the doubled-geoid bug
-                        # before downstream consumers see the sentence.
+                        # in any base-corrected mode (DGPS / RTK Float / RTK
+                        # Fixed), normalise away the doubled-geoid bug before
+                        # downstream consumers see the sentence.
                         q = self._gga_quality(line)
                         if q is not None:
                             with self._quality_lock:
                                 self._last_quality = q
-                            if q >= 4:
+                            if 2 <= q <= 5:
                                 line = self._zero_gga_geoid_separation(line)
                         msg = Sentence()
                         msg.header.stamp = self.get_clock().now().to_msg()


### PR DESCRIPTION
## Summary

UM980 (Witmotion WTRTK-980) shows an unexpected GGA behaviour as soon as base-station corrections are active: in DGPS, RTK Float and RTK Fixed modes (`quality` field 2, 3, 4, 5), the receiver puts the rover's HAE in GGA field 9 (the spec-defined "MSL altitude" slot) but still emits the geoid separation in field 11. `nmea_navsat_driver`'s naive `altitude = msl + geoid_sep` then produces a doubled geoid offset.

This patch detects any of those modes in the bridge, rewrites field 11 to `0.0`, recomputes the NMEA checksum, and republishes. Downstream consumers see a consistent altitude across all fix qualities.

Pure SPP (q=1) remains spec-compliant — field 9 is real MSL — and is **not** rewritten.

## Symptom (pre-patch, on a mower with local NTRIP base in southern Germany)

```
SPP   (q=1)  /gps/fix.altitude  ~577 m   ← correct HAE (driver added geoid_sep to MSL)
DGPS  (q=2)  /gps/fix.altitude  ~617 m   ← wrong (field 9 is HAE, +geoid_sep = +47 m bug)
RTK   (q=4/5) /gps/fix.altitude  ~620 m  ← wrong (same mechanism)
```

The ~47 m offset matches the EGM2008 geoid undulation in this region. The Unicore N4 manual (Table 7-4) documents field 10 as "Altitude above/below MSL (geoid)" with no mode-dependent switch — so this looks like firmware behaviour rather than spec-conforming output.

## Downstream impact

FusionCore was diverging severely on this hardware:
- `/fusion/odom` z-position: **65 283 m** with covariances around 10⁸
- Mahalanobis gate (issue #21) almost certainly rejecting clean RTK fixes because every transition into a corrected mode looked like a 47 m altitude jump

After patch + correct `datum_alt` setting:
- `/fusion/odom` z-position: **0.56 m** (matches physical antenna height above the datum reference)
- `/gps/fix.altitude` in DGPS: **580 m** (was ~617 m pre-patch)
- `/gps/fix.altitude` in RTK Float: **576 m** (was ~620 m pre-patch)

Both now in the expected ~566–572 m HAE range for Eichenau.

## Implementation

In `nmea_serial_bridge.py`:
- New `_zero_gga_geoid_separation(line)` helper: splits at `*`, sets field 11 to `0.0`, recomputes XOR checksum, returns reformatted sentence.
- The existing GGA-quality-tracking path now also calls the helper when `2 <= q <= 5`, **before** the sentence is published on `/nmea_sentence`.
- Non-GGA sentences and SPP-mode GGAs are passed through unchanged.

## Test plan

- [x] Unit-test of the helper against captured GGAs (Q=1 passthrough, Q=2 rewrite, Q=4 rewrite, Q=5 rewrite, RMC passthrough). Checksum self-verification confirmed.
- [x] **Pi5 live deploy** via `docker cp` + `docker restart mowgli-gps`.
  - DGPS (Q=2): `/nmea_sentence` shows `…,2,…,579.79,M,0.0,M,…` and `/gps/fix.altitude` 579.85 m (was ~617 m pre-patch).
  - RTK Float (Q=5): `/gps/fix.altitude` 576.25 m (was ~620 m pre-patch).
  - `/fusion/odom` z: 0.56 m (was 65283 m pre-patch).
- [ ] RTK Fixed (Q=4) verification — only RTK Float observed on the bench so far; same mechanism, expect identical result.
- [ ] Long-running stability check that FusionCore stays converged through repeated mode transitions.

## Notes on a possible receiver-side fix

The Unicore N4 commands manual (Section 4.4) documents `CONFIG UNDULATION [parameter]`, where the parameter is either `Auto` (default, use built-in geoid grid) or a numeric value in `[-1000.0000, +1000.0000] m`. The example shown is `CONFIG UNDULATION 9.7`. It is plausible — but **not explicitly documented** — that setting it to `0.0` would force the GGA geoid-separation field to zero at source. Needs receiver-side bench validation before being relied on.

The bridge-side workaround in this PR is more robust regardless:
- Mode-aware (only modifies corrected GGAs, leaves SPP untouched).
- Independent of receiver configuration that could be wiped by a factory reset or firmware update.
- Works for any future receiver that exhibits the same behaviour.

So this PR stays as the primary fix; the receiver-side `CONFIG UNDULATION` exploration belongs in the upcoming UM980-driver work as a possible additional safety net, pending verification.

Likely also closes the practical symptom of #21 (FusionCore Mahalanobis gate rejecting RTK fixes); the underlying gate-tuning concern remains its own discussion.

Bridge image needs to be rebuilt and pushed to `:dev` before non-bench installs see the fix. Watchtower will pick up the new image on the test bench automatically.