### PR TITLE
fix(gui/cdr): use CDR1 alignment (8-byte, payload-relative) for rmw_cyclonedds

### DIFF
--- a/gui/pkg/foxglove/cdr.go
+++ b/gui/pkg/foxglove/cdr.go
@@ -252,10 +252,14 @@ func DeserializeCDR(data []byte, schema *msgSchema) (map[string]interface{}, err
 	}
 
 	// Encapsulation header: byte 1 encodes endianness (0x01 = LE).
-	// ROS2 Jazzy uses PLAIN_CDR2 encoding which caps alignment at 4 bytes,
-	// regardless of the encapsulation header value.
+	// rmw_cyclonedds on ROS 2 Kilted publishes PLAIN_CDR (XCDR1) for topics,
+	// which uses 8-byte natural alignment (relative to the payload start, not
+	// the buffer start). The earlier code assumed CDR2 (maxAlign=4 absolute)
+	// and corrupted any message whose layout placed a float64 after a string
+	// of an offset that differed between the two schemes — see
+	// CalibrateImuYawStatus.
 	le := data[1] == 0x01
-	r := &cdrReader{data: data, offset: 4, le: le, maxAlign: 4}
+	r := &cdrReader{data: data, offset: 4, le: le, maxAlign: 8}
 
 	return r.readMessage(schema.Fields)
 }
@@ -563,6 +567,10 @@ func (r *cdrReader) readUint64() (uint64, error) {
 }
 
 // align advances offset to the next multiple of n, capped by maxAlign.
+// Alignment is measured RELATIVE TO THE PAYLOAD START (after the 4-byte
+// encapsulation header), matching CDR's own convention and what the writer
+// produces. Modulo'ing the absolute buffer offset would push every 8-byte
+// alignment 4 bytes too late.
 func (r *cdrReader) align(n int) {
 	if n <= 1 {
 		return
@@ -570,7 +578,7 @@ func (r *cdrReader) align(n int) {
 	if n > r.maxAlign {
 		n = r.maxAlign
 	}
-	rem := r.offset % n
+	rem := (r.offset - cdrEncapHeaderLen) % n
 	if rem != 0 {
 		r.offset += n - rem
 	}

--- a/gui/pkg/foxglove/cdr_write.go
+++ b/gui/pkg/foxglove/cdr_write.go
@@ -15,14 +15,15 @@ func SerializeCDR(jsonData []byte, schema *msgSchema) ([]byte, error) {
 		return nil, fmt.Errorf("cdr write: unmarshal: %w", err)
 	}
 
-	// ROS 2 Kilted with the default rmw stack negotiates PLAIN_CDR2 over the
-	// wire — primitives align at most to 4 bytes regardless of the encap
-	// representation byte (this matches cdrReader's maxAlign=4 used in
-	// DeserializeCDR). With maxAlign=8 here the writer pushed leading float64
-	// fields one 8-byte slot too far, so e.g. SetDockingPoint's Pose decoded
-	// to garbage on the C++ side because position.x landed at byte 8 while
-	// rmw was reading it at byte 4.
-	w := &cdrWriter{maxAlign: 4}
+	// rmw_cyclonedds on ROS 2 Kilted uses PLAIN_CDR (XCDR1): up to 8-byte
+	// natural alignment, measured relative to the payload start (after the
+	// 4-byte encapsulation header). The earlier maxAlign=4 cap matched the
+	// reader's previous CDR2 assumption — both have been corrected together.
+	// SetDockingPoint stays correct because its 7 consecutive float64 fields
+	// land on the same offsets under both alignment caps anyway; the
+	// breakage we hit before was the absolute-vs-payload-relative align()
+	// bug, fixed in cdrWriter.align below.
+	w := &cdrWriter{maxAlign: 8}
 	// Encapsulation header: representation_id + options. ROS 2 publishers
 	// emit 0x0001 0x0000 (CDR_LE) regardless of the actual XCDR variant.
 	// Alignment is measured from the start of the payload (the byte AFTER

--- a/gui/pkg/foxglove/cdr_write_test.go
+++ b/gui/pkg/foxglove/cdr_write_test.go
@@ -2,6 +2,7 @@ package foxglove
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"math"
 	"testing"
 
@@ -128,4 +129,109 @@ func TestSerializeCDR_SingleFloat64PadsToMultipleOfEight(t *testing.T) {
 
 	// Trailing four bytes must be zero pad, not random memory.
 	assert.Equal(t, []byte{0, 0, 0, 0}, out[12:16], "trailing pad zeros")
+}
+
+// CalibrateImuYawStatus.msg schema as advertised by foxglove_bridge for
+// /calibrate_imu_yaw_node/calibrate_status — mixed primitives that exercise
+// every alignment edge in the reader.
+const calibrateImuYawStatusSchema = `string job_id
+bool done
+bool success
+string message
+float64 imu_yaw_rad
+float64 imu_yaw_deg
+int32 samples_used
+float64 std_dev_deg
+float64 imu_pitch_rad
+float64 imu_pitch_deg
+float64 imu_roll_rad
+float64 imu_roll_deg
+int32 stationary_samples_used
+float64 gravity_mag_mps2
+`
+
+// TestSerializeCDR_CalibrateImuYawStatusRoundTrip exercises the CDR reader
+// against the EXACT shape that triggered the GUI's "samples_used = -1071219282"
+// garbage display. Values are taken from a live Pi5 capture of
+// /calibrate_imu_yaw_node/calibrate_status (verified clean via ros2 topic echo)
+// where the GUI then mis-displayed them.
+//
+// If this round-trip succeeds, the cdr.go reader handles the shape correctly
+// and the bug is downstream (wire encoding from foxglove_bridge differs from
+// what the writer produces). If it fails, the reader has a bug for this shape.
+func TestSerializeCDR_CalibrateImuYawStatusRoundTrip(t *testing.T) {
+	schema, err := ParseSchema(calibrateImuYawStatusSchema)
+	require.NoError(t, err)
+
+	jsonReq := []byte(`{
+		"job_id": "47fe01d54c94a7d2a7ec9240",
+		"done": true,
+		"success": true,
+		"message": "imu_yaw=-11.25 deg from 263 samples",
+		"imu_yaw_rad": -0.1962704701472458,
+		"imu_yaw_deg": -11.245469582485601,
+		"samples_used": 263,
+		"std_dev_deg": 49.59494910238911,
+		"imu_pitch_rad": 0.016132494450135544,
+		"imu_pitch_deg": 0.9243238450109904,
+		"imu_roll_rad": -0.06137728957413168,
+		"imu_roll_deg": -3.5166596505500554,
+		"stationary_samples_used": 378,
+		"gravity_mag_mps2": 11.305172532189346
+	}`)
+
+	wire, err := SerializeCDR(jsonReq, schema)
+	require.NoError(t, err)
+	t.Logf("wire payload size: %d bytes", len(wire))
+
+	decoded, err := DeserializeCDR(wire, schema)
+	require.NoError(t, err)
+
+	assert.Equal(t, "47fe01d54c94a7d2a7ec9240", decoded["job_id"])
+	assert.Equal(t, true, decoded["done"])
+	assert.Equal(t, true, decoded["success"])
+	assert.Equal(t, "imu_yaw=-11.25 deg from 263 samples", decoded["message"])
+	assert.InDelta(t, -0.1962704701472458, decoded["imu_yaw_rad"], 1e-12)
+	assert.InDelta(t, -11.245469582485601, decoded["imu_yaw_deg"], 1e-12)
+	assert.Equal(t, int32(263), decoded["samples_used"])
+	assert.InDelta(t, 49.59494910238911, decoded["std_dev_deg"], 1e-12)
+	assert.InDelta(t, 0.016132494450135544, decoded["imu_pitch_rad"], 1e-12)
+	assert.InDelta(t, 0.9243238450109904, decoded["imu_pitch_deg"], 1e-12)
+	assert.InDelta(t, -0.06137728957413168, decoded["imu_roll_rad"], 1e-12)
+	assert.InDelta(t, -3.5166596505500554, decoded["imu_roll_deg"], 1e-12)
+	assert.Equal(t, int32(378), decoded["stationary_samples_used"])
+	assert.InDelta(t, 11.305172532189346, decoded["gravity_mag_mps2"], 1e-12)
+}
+
+// TestDeserializeCDR_CalibrateImuYawStatusGoldenWire decodes a captured wire
+// payload of /calibrate_imu_yaw_node/calibrate_status from a live Pi5
+// (rmw_cyclonedds, ROS 2 Kilted) and asserts every field matches what
+// `ros2 topic echo` reported on the publisher side.
+//
+// Before the cdr.go align fix, the reader (with maxAlign=4 and absolute-from-
+// buffer alignment) read garbage starting at imu_yaw_rad — the GUI's surface
+// symptom was "samples_used = -1071219282".
+func TestDeserializeCDR_CalibrateImuYawStatusGoldenWire(t *testing.T) {
+	schema, err := ParseSchema(calibrateImuYawStatusSchema)
+	require.NoError(t, err)
+
+	wire, err := hex.DecodeString("0001000019000000343766653031643534633934613764326137656339323430000101008f000000696d755f7961773d2d31312e3235c2b02066726f6d203236332073616d706c65732028766563746f7220523d302e36392c207065722d73616d706c6520523d302e3539292e2070697463683d302e3932c2b020726f6c6c3d2d332e3532c2b02066726f6d203337382073746174696f6e6172792073616d706c657320287c677c3d31312e3331206d2f73c2b2292e000000000000c2fa3909641fc9bf7ae06930ae7d26c00701000000000000dcc5cc4a27cc4840c2d243600985903f9186a7990f94ed3fcf43e016d86cafbfc43372741e220cc07a0100000000000010c8fa923f9c2640")
+	require.NoError(t, err)
+
+	decoded, err := DeserializeCDR(wire, schema)
+	require.NoError(t, err)
+
+	assert.Equal(t, "47fe01d54c94a7d2a7ec9240", decoded["job_id"])
+	assert.Equal(t, true, decoded["done"])
+	assert.Equal(t, true, decoded["success"])
+	assert.InDelta(t, -0.1962704701472458, decoded["imu_yaw_rad"], 1e-12)
+	assert.InDelta(t, -11.245469582485601, decoded["imu_yaw_deg"], 1e-12)
+	assert.Equal(t, int32(263), decoded["samples_used"])
+	assert.InDelta(t, 49.59494910238911, decoded["std_dev_deg"], 1e-12)
+	assert.InDelta(t, 0.016132494450135544, decoded["imu_pitch_rad"], 1e-12)
+	assert.InDelta(t, 0.9243238450109904, decoded["imu_pitch_deg"], 1e-12)
+	assert.InDelta(t, -0.06137728957413168, decoded["imu_roll_rad"], 1e-12)
+	assert.InDelta(t, -3.5166596505500554, decoded["imu_roll_deg"], 1e-12)
+	assert.Equal(t, int32(378), decoded["stationary_samples_used"])
+	assert.InDelta(t, 11.305172532189346, decoded["gravity_mag_mps2"], 1e-12)
 }


### PR DESCRIPTION
## Summary

The GUI's CDR reader assumed CDR2 layout (`maxAlign=4`, alignment computed from absolute buffer offset). `rmw_cyclonedds` on ROS 2 Kilted publishes topic data as PLAIN_CDR (XCDR1) — up-to-8-byte natural alignment, measured from the start of the payload (after the 4-byte encapsulation header).

This patch:

- Bumps `maxAlign` from 4 to 8 in both `cdrReader` and `cdrWriter`.
- Switches `cdrReader.align()` to compute the modulo from the payload-relative offset, matching `cdrWriter.align()`'s existing convention and the wire layout produced by rmw_cyclonedds.
- Adds two regression tests for `CalibrateImuYawStatus` — the message shape that surfaced the bug.

## Symptom

`CalibrateImuYawStatus.msg` has the layout `string + bool + bool + string + float64 + float64 + int32 + ... + float64 + int32 + float64`. After the 143-byte `message` string, the wire payload places `imu_yaw_rad` at payload offset **184** (CDR1: 5 bytes of pad to reach the next 8-byte boundary). The buggy reader, capped at 4-byte alignment, advanced by only 1 byte to payload offset **180** and decoded the trailing zero-pad bytes as the float — and then slid every subsequent field by 4 bytes.

Surface symptom in the GUI calibration page:

```
imu_yaw = 0.00° (0.0000 rad)
Confidence ±0.00° from -1071219282 valid samples.
```

The `0.00°` values are the misread zero-pad bytes; the negative sample count is an int32 read from a misaligned position inside the next float64.

## Why it slipped through

Pose-only messages (e.g. `SetDockingPoint` with 7 consecutive float64 fields) are unaffected — both alignment caps produce identical offsets when there are no narrower primitives mixed in. The existing `TestSerializeCDR_RoundTripsThroughReader` only exercises that case, so the latent CDR1/CDR2 mismatch never surfaced until a topic with a string-then-float64 layout was added.

## Pi5 wire capture

Captured `/calibrate_imu_yaw_node/calibrate_status` payload (rmw_cyclonedds, ROS 2 Kilted) decoded byte-by-byte:

```
buf=183  message string ends
buf=184  reader (cap=4): float64 starts here  → reads 0x00000000 c2fa3909 → 3.22e-264 (≈ 0)
buf=188  CDR1 (8-byte align): float64 starts here  → reads 0xc2fa3909 641fc9bf → -0.196270470147245801 ✓
```

The 4-byte gap propagates through the rest of the message — every subsequent float64 / int32 reads garbage.

## Test plan

- [x] `go test ./pkg/foxglove/` — all 5 tests pass:
  - `TestSerializeCDR_PoseFloat64Alignment` — pre-existing
  - `TestSerializeCDR_RoundTripsThroughReader` — pre-existing
  - `TestSerializeCDR_SingleFloat64PadsToMultipleOfEight` — pre-existing
  - `TestSerializeCDR_CalibrateImuYawStatusRoundTrip` — new, synthetic round-trip
  - `TestDeserializeCDR_CalibrateImuYawStatusGoldenWire` — new, fixture decode of captured Pi5 wire payload
- [x] **Pi5 deploy**: cross-built binary, hot-swapped into `mowgli-gui` container, restarted. Browser calibration page now shows real values (`imu_yaw = 0.75°, 219 valid samples`) instead of zeros and `-1071219282`.
- [ ] Regression sweep against other topic subscriptions in the GUI — most use float-heavy or simple shapes that the bug didn't touch, so no behaviour change expected, but a deliberate eyes-on of the dashboard for ~10 minutes after deploy is sensible.

## Notes

- The `SetDockingPoint` writer fix (commit history) was specifically about the absolute-vs-payload-relative align bug for the *writer*. That fix was correct; the additional `maxAlign=4` cap it introduced was a defensive over-correction that this patch reverts in favour of the proper CDR1 layout.
- A more general implementation would mode-detect the encapsulation header (0x00/0x01 = CDR1, 0x11/0x12 = CDR2) and pick `maxAlign` accordingly. Hardcoded to 8 here because rmw_cyclonedds-on-Kilted is the entire deployment surface today; revisit if the project ever switches DDS or upgrades to a CDR2-default rmw.
- Likely also fixes any other shapes I haven't seen yet that mix narrow primitives with float64s.