### PR TITLE
fix(firmware/drivemotor): smooth additive stiction-overcome offset

### DIFF
--- a/firmware/stm32/ros_usbnode/src/drivemotor.c
+++ b/firmware/stm32/ros_usbnode/src/drivemotor.c
@@ -110,15 +110,57 @@ static uint8_t right_speed_req;
 static uint8_t left_dir_req;
 static uint8_t right_dir_req;
 
-/* No host-side PWM deadband: the PAC5210 drive-motor controller runs its
- * own internal loop and handles sub-threshold commands gracefully (this
- * is how the original cedbossneo/mowgli firmware behaved, and it worked
- * fine). Adding a host-side deadband promotion on 2026-04-19 introduced
- * a 2.5× angular overshoot at low wz — any command between [-34, -1] ∪
- * [1, 34] got snapped to ±35, so wz=0.30 rad/s produced physical rotation
- * at ~0.72 rad/s. Confirmed in Voie C Test 2026-04-24 (commanded 90°
- * → measured 225° physical). The fix is to pass PWM through unchanged
- * and let the motor controller handle its own dynamics. */
+/* PWM stiction-overcome offset.
+ *
+ * History:
+ *   - 2026-04-19: removed a host-side ±35 PWM snap-up that caused 2.5×
+ *     angular overshoot at low wz (Voie C Test: commanded 90° → measured
+ *     225°). The snap promoted any |x| in [1,34] to exactly ±35 — fine for
+ *     pure forward motion but a disaster for small differential commands.
+ *   - 2026-04-25: nav2_velocity_smoother deadband lowered 0.13 → 0.04 m/s
+ *     (PR #17) so undock could push small reverse commands through. This
+ *     left a window where commands of 0.04–0.10 m/s reach the firmware as
+ *     12–30 PWM units — under typical static-friction threshold for the
+ *     drive motors, so the wheels twitch but do not actually rotate.
+ *
+ * Today's compromise: a SMOOTH additive offset that decays linearly with
+ * commanded magnitude. Any non-zero command is bumped up just enough to
+ * overcome stiction; above STICTION_TAPER_END_PWM the bump is zero and
+ * the command passes through unchanged.
+ *
+ *   effective = magnitude + STICTION_PWM * max(0, TAPER_END - magnitude) / TAPER_END
+ *
+ * Tuning targets:
+ *   - STICTION_PWM: just enough to overcome static friction on a level
+ *     surface (motor-dependent, empirical). Too low → wheels still
+ *     twitch. Too high → angular overshoot creeps back in. Bench-test
+ *     by sending small wz commands and measuring physical rotation.
+ *   - STICTION_TAPER_END_PWM: where the help should disappear entirely.
+ *     Too low → small commands still under-power. Too high → distortion
+ *     of the lower dynamic range, which re-introduces overshoot at low wz.
+ *
+ * Values below are conservative defaults; tune per bench observation. */
+#define STICTION_PWM             10
+#define STICTION_TAPER_END_PWM   25
+
+static int16_t apply_stiction_offset(int16_t pwm_signed)
+{
+    if (pwm_signed == 0) {
+        return 0;
+    }
+    int16_t magnitude = (pwm_signed < 0) ? -pwm_signed : pwm_signed;
+    int16_t offset = 0;
+    if (magnitude < STICTION_TAPER_END_PWM) {
+        offset = (int16_t)(((int32_t)STICTION_PWM *
+                            (STICTION_TAPER_END_PWM - magnitude)) /
+                           STICTION_TAPER_END_PWM);
+    }
+    int16_t result = magnitude + offset;
+    if (result > 255) {
+        result = 255;
+    }
+    return (pwm_signed > 0) ? result : -result;
+}
 
 /******************************************************************************
  * Function Prototypes
@@ -497,14 +539,21 @@ void DRIVEMOTOR_App_Rx(void)
  * forward, negative = reverse, 0 = stop. The motor-controller PCB's legacy
  * (|speed|, direction-bit) interface is produced internally by this function.
  *
- * No host-side deadband: the PAC5210 motor controller handles sub-threshold
- * commands on its own. Saturates to 8-bit motor-controller magnitude range.
+ * Applies a smooth stiction-overcome offset (see apply_stiction_offset
+ * comment block above) so small commands actually break static friction
+ * instead of just buzzing the motor. Saturates to 8-bit motor-controller
+ * magnitude range.
  *
  * @param  left_pwm_signed   signed PWM command for the left wheel
  * @param  right_pwm_signed  signed PWM command for the right wheel
  */
 void DRIVEMOTOR_SetSpeedSigned(int16_t left_pwm_signed, int16_t right_pwm_signed)
 {
+    /* Friction-overcome offset BEFORE saturation so the offset can push
+     * a borderline command up into the moving range without exceeding 255. */
+    left_pwm_signed  = apply_stiction_offset(left_pwm_signed);
+    right_pwm_signed = apply_stiction_offset(right_pwm_signed);
+
     /* Saturate to the 8-bit motor-controller magnitude. */
     if (left_pwm_signed  >  255) left_pwm_signed  =  255;
     if (left_pwm_signed  < -255) left_pwm_signed  = -255;

--- a/firmware/stm32/ros_usbnode/src/drivemotor.c
+++ b/firmware/stm32/ros_usbnode/src/drivemotor.c
@@ -140,8 +140,8 @@ static uint8_t right_dir_req;
  *     of the lower dynamic range, which re-introduces overshoot at low wz.
  *
  * Values below are conservative defaults; tune per bench observation. */
-#define STICTION_PWM             10
-#define STICTION_TAPER_END_PWM   25
+#define STICTION_PWM             20
+#define STICTION_TAPER_END_PWM   30
 
 static int16_t apply_stiction_offset(int16_t pwm_signed)
 {


### PR DESCRIPTION
## Summary

Restore enough motor PWM "kick" to break static friction at low commanded speeds, **without** re-introducing the 2.5× angular overshoot from the original ±35 snap-up.

## The problem

Two prior fixes left the PWM chain in a state where small commands reach the motors but don't actually move them:

| Date | Change | Effect |
|---|---|---|
| 2026-04-19 | Removed host-side ±35 PWM snap-up | Fixed 2.5× wz overshoot (Voie C Test: cmd 90° → measured 225°) |
| 2026-04-25 | `nav2_velocity_smoother.deadband` 0.13 → 0.04 m/s (#17) | Unblocked 0-cm undock |

Now `0.04–0.10 m/s` (= 12–30 PWM units) commands reach the firmware unchanged, **below** the drive motors' static-friction threshold. Wheels buzz, don't rotate.

Live observation today on Pi5 during a mow attempt:

```
FTC: state=1 idx=0/94  lat=-0.001 lon=-0.027 ang=0.014  pos=(-0.03,-0.00)
                             ↑ 2.7 cm of "go forward"

hardware_bridge: Odom: dL=0  dR=0  (every 100 ms, for 10+ s)
controller_server: FTCController: resyncing carrot idx 0->0 (×10 Hz)
```

FTC keeps trying, encoders see no motion, carrot never advances, BT stays in MOWING until low battery.

## The fix

A smooth additive offset that decays linearly with commanded magnitude:

```
effective_pwm = magnitude + STICTION_PWM * max(0, TAPER_END - magnitude) / TAPER_END
```

Above `STICTION_TAPER_END_PWM`, the bump is zero — large-magnitude motion is unchanged. Both `#define` constants are at the top of the helper for bench tuning.

### Numerical behaviour (STICTION_PWM=10, TAPER_END=25)

| input | output | promotion |
|---|---|---|
| 0 | 0 | — (zero stays zero) |
| 1 | 10 | 10.00× (snap to friction floor) |
| 5 | 13 | 2.60× |
| 10 | 16 | 1.60× |
| 15 | 19 | 1.27× |
| 20 | 22 | 1.10× |
| 25 | 25 | 1.00× |
| 100+ | passthrough | 1.00× |

### Comparison to the broken old fix at wz=0.30 rad/s

That's the case that justified removing the snap. Differential PWM ≈ 22 per wheel:

- Old snap (±35): 22 → 35 = 1.59× promotion → ~2.5× angular overshoot (the Voie C result)
- This patch: 22 → 23 = 1.05× promotion → expected ~1.05× angular overshoot (well under the 1.5× bench threshold)

## Test plan

- [x] Unit-style sanity check: built and ran the helper standalone with the conservative defaults; verified the table above and that negative commands behave symmetrically.
- [ ] **Firmware flash on the Pi5 bench** — STM32 needs reflash via ST-Link on J9. Not run during PR creation; bench was returning to dock at low battery when this was committed.
- [ ] Live FTC test: trigger mowing on a known-good polygon, confirm encoders show non-zero `dL`/`dR` for any commanded `cmd_vel`, confirm `idx` advances on `/cmd_vel_nav` matching the strip path.
- [ ] Pure-rotation overshoot test: command `wz=0.30 rad/s` for a known angle, measure physical rotation, confirm overshoot < 1.2× (was 2.5× under the old snap-up).

## Tuning notes

If after flashing this patch:

- Wheels still twitch without rotating → raise `STICTION_PWM` (try 12, 15)
- Low-wz rotations start overshooting again → lower `STICTION_TAPER_END_PWM` (narrows the help region) before lowering `STICTION_PWM`
- Commands feel lurchy at the boundary (around 25 PWM) → narrow taper or raise both proportionally

Both constants live at the top of the helper for fast bench iteration.