### PR TITLE
fix(firmware/openocd): use interface/stlink.cfg + transport swd for OpenOCD 0.12+

### DIFF
--- a/firmware/stm32/ros_usbnode/remote_upload/yardforce500.cfg
+++ b/firmware/stm32/ros_usbnode/remote_upload/yardforce500.cfg
@@ -1,6 +1,9 @@
-# tested with Open On-Chip Debugger 0.10.0 on Ubuntu 20.04
+# Tested with OpenOCD 0.10.0 on Ubuntu 20.04 and 0.12.0 on Raspberry Pi OS
+# bookworm. The interface/stlink-v2.cfg + transport hla_swd combo was deprecated
+# in 0.12+ and now fails on init with "Can't change session's transport after
+# the initial selection was made". Switched to interface/stlink.cfg + plain swd
+# which is the upstream-recommended form since OpenOCD 0.11.
 
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
+transport select swd
 source [find target/stm32f1x.cfg]
-
-transport select hla_swd


### PR DESCRIPTION
## Summary

The `remote_upload/yardforce500.cfg` used the legacy `interface/stlink-v2.cfg` plus a trailing `transport select hla_swd`. On OpenOCD 0.12+ (currently shipping with Raspberry Pi OS bookworm) the new ST-Link interface auto-selects swd (dapdirect) on load, then refuses to honour the later `transport select`:

```
Can't change session's transport after the initial selection was made
```

Result: manual flashing on the Pi5 fails on the first invocation, and every operator has to monkey-patch `/tmp/yardforce500.cfg` before `openocd` will run.

This patch switches to the upstream-recommended form (since OpenOCD 0.11): source `interface/stlink.cfg`, set transport to `swd` explicitly **before** sourcing the target.

## Reproduction (pre-patch)

```
$ openocd -f yardforce500.cfg -f prog.cfg
Open On-Chip Debugger 0.12.0+dev-snapshot
WARNING: interface/stlink-v2.cfg is deprecated, please switch to interface/stlink.cfg
Warn : DEPRECATED: auto-selecting transport "swd (dapdirect)". Use 'transport select swd' to suppress this message.
Can't change session's transport after the initial selection was made
```

## Verification (post-patch)

End-to-end flash on a Pi5 with ST-Link V2 wired to the Yardforce500 J9 connector:

```
$ sudo openocd -f yardforce500.cfg -f prog.cfg
Info : STLINK V2J37S7 (API v2) VID:PID 0483:3748
Info : Target voltage: 3.127742
Info : [stm32f1x.cpu] Cortex-M3 r1p1 processor detected
** Programming Started **
Info : flash size = 256 KiB
** Programming Finished **
** Verify Started **
** Verified OK **
** Resetting Target **
shutdown command invoked
```

`sudo` is still needed because non-root pi user lacks libusb access to the ST-Link — that's a separate udev-rule fix worth doing in a follow-up but unrelated to this config error.

## Scope

- Touched: `firmware/stm32/ros_usbnode/remote_upload/yardforce500.cfg` only.
- Not touched: `firmware/stm32/mainboard_firmware/yardforce500.cfg` has the same bug but lives in a standalone backup/restore utility on a different code path. Left for follow-up.
- The GUI flash path uses `platformio run -t upload` (`gui/pkg/providers/firmware.go:127`) with its own internal openocd configuration — unaffected by this change.

## Test plan

- [x] Flashed firmware end-to-end on Pi5 with the patched config in place (the bench unit). Verified the "** Verified OK **" line and clean reset.
- [ ] No regression possible for OpenOCD < 0.11 on this exact change because `interface/stlink.cfg` and `transport select swd` are both supported there too. Modern Raspberry Pi OS, Debian, Ubuntu all ship 0.11+.