### PR TITLE
fix(battery): full-voltage default 28.5→28.0 + low-pass filter for spike-resistant percent

### DIFF
--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -390,8 +390,8 @@
         "battery_full_voltage": {
           "type": "number",
           "title": "Full Voltage",
-          "default": 28.5,
-          "description": "Voltage at which battery is considered full."
+          "default": 28.0,
+          "description": "Voltage at which battery is considered full. Yardforce500 SLA packs top out around 28.0 V on the dock; setting this higher caps the displayed percentage below 100%."
         },
         "battery_empty_voltage": {
           "type": "number",

--- a/gui/web/src/utils/battery.ts
+++ b/gui/web/src/utils/battery.ts
@@ -1,6 +1,6 @@
 /** Default battery voltage thresholds — must match mower_config.schema.json */
 export const BATTERY_DEFAULTS = {
-    fullVoltage: 28.5,
+    fullVoltage: 28.0,
     emptyVoltage: 24.0,
     criticalVoltage: 23.0,
 } as const;

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -114,11 +114,39 @@ private:
                                      std::lock_guard<std::mutex> lock(context_->context_mutex);
                                      context_->latest_power = *msg;
 
-                                     // Derive battery_percent from voltage using
+                                     // Low-pass filter v_battery before computing the
+                                     // percentage. Without this, brief load spikes from
+                                     // motor PWM startup transients sag the rail by
+                                     // 0.5–1 V for a few hundred ms — long enough to drag
+                                     // battery_percent below the NeedsDocking threshold
+                                     // and trip a spurious LOW_BATTERY_DOCKING even
+                                     // though the no-load voltage is well above. With
+                                     // ALPHA=0.05 at the topic's ~10 Hz update rate, the
+                                     // filter has a ~2 s time constant — load transients
+                                     // are smoothed but real discharge is tracked
+                                     // closely enough.
+                                     constexpr float kVBatteryFilterAlpha = 0.05f;
+                                     constexpr float kVBatterySanityFloor = 10.0f;  // V
+                                     if (msg->v_battery >= kVBatterySanityFloor) {
+                                       if (filtered_v_battery_ <= 0.0f) {
+                                         // Bootstrap on first valid sample — no jump on init.
+                                         filtered_v_battery_ = msg->v_battery;
+                                       } else {
+                                         filtered_v_battery_ =
+                                             (1.0f - kVBatteryFilterAlpha) * filtered_v_battery_ +
+                                             kVBatteryFilterAlpha * msg->v_battery;
+                                       }
+                                     }
+                                     // If v_battery is implausibly low (sensor glitch,
+                                     // disconnected pack), keep the previous filtered
+                                     // value so the BT doesn't act on spurious zeros.
+
+                                     // Derive battery_percent from filtered voltage using
                                      // configurable thresholds from ROS parameters.
                                      const float v_max = battery_full_voltage_;
                                      const float v_min = battery_empty_voltage_;
-                                     const float clamped = std::clamp(msg->v_battery, v_min, v_max);
+                                     const float clamped =
+                                         std::clamp(filtered_v_battery_, v_min, v_max);
                                      context_->battery_percent =
                                          100.0f * (clamped - v_min) / (v_max - v_min);
                                    });
@@ -420,6 +448,9 @@ private:
   // Battery voltage curve parameters
   float battery_full_voltage_{28.0f};
   float battery_empty_voltage_{24.0f};
+  // Low-pass filtered v_battery for spike-resistant battery_percent. 0.0 = uninitialised
+  // (bootstrap on first valid sample to avoid an artificial dip from zero on startup).
+  float filtered_v_battery_{0.0f};
 };
 
 }  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -330,7 +330,7 @@ private:
 
     // Battery voltage curve — configurable via mowgli_robot.yaml
     battery_full_voltage_ =
-        static_cast<float>(declare_parameter<double>("battery_full_voltage", 28.5));
+        static_cast<float>(declare_parameter<double>("battery_full_voltage", 28.0));
     battery_empty_voltage_ =
         static_cast<float>(declare_parameter<double>("battery_empty_voltage", 24.0));
 
@@ -418,7 +418,7 @@ private:
   bool undock_ready_{false};
 
   // Battery voltage curve parameters
-  float battery_full_voltage_{28.5f};
+  float battery_full_voltage_{28.0f};
   float battery_empty_voltage_{24.0f};
 };
 

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -80,7 +80,7 @@ mowgli:
     # -----------------------------------------------------------------
     # Battery
     # -----------------------------------------------------------------
-    battery_full_voltage: 28.5     # consider fully charged above this
+    battery_full_voltage: 28.0     # consider fully charged above this — Yardforce500 SLA tops out at ~28.0V
     battery_empty_voltage: 24.0    # dock if below for sustained period
     battery_critical_voltage: 23.0 # immediate dock
     battery_full_percent: 95.0     # resume mowing above this %


### PR DESCRIPTION
## Summary

Two related battery-percentage bugs surfaced live on the Pi5:

1. **"Charges only to 89%"** — the default `battery_full_voltage` of 28.5 V is higher than what a Yardforce500 SLA pack actually reaches on the dock (~28.0 V). The linear interpolation `(28.0 - 24.0) / (28.5 - 24.0) * 100` capped the displayed level at 88.9%.
2. **"LOW_BATTERY at 35%"** — the BT `NeedsDocking` trigger (20 % threshold) fired correctly while motors were under load and the battery rail was sagging 0.5–1 V from PWM startup transients. By the time the user looked at the GUI the rail had recovered, showing ~35 % — but the trigger had already happened.

Two commits, one PR.

## Commit 1: lower default to 28.0 V

Touches all four sites that hold the constant:
- `behavior_tree_node.cpp` (`declare_parameter` default + class member init)
- `mowgli_bringup/config/mowgli_robot.yaml` (live BT param source)
- `gui/web/src/utils/battery.ts` (`BATTERY_DEFAULTS.fullVoltage` — frontend fallback)
- `gui/asserts/mower_config.schema.json` (default + description)

After merge, a fully charged 28.0 V pack reads 100 % in the GUI. Operators with packs that genuinely reach 28.5 V can override via `battery_full_voltage` in their `mowgli_robot.yaml`. The default was simply miscalibrated for the platform we actively support.

NeedsDocking math also shifts marginally: `0.20 * (28.0 - 24.0) + 24 = 24.8 V` (was 24.9 V). Effectively unchanged.

## Commit 2: low-pass filter v_battery

Adds an alpha-blend filter on `v_battery` inside the `/hardware_bridge/power` callback in `behavior_tree_node.cpp`:

```cpp
constexpr float kVBatteryFilterAlpha = 0.05f;     // ~2 s time constant at 10 Hz
constexpr float kVBatterySanityFloor = 10.0f;     // V — reject obviously bad samples

if (msg->v_battery >= kVBatterySanityFloor) {
    if (filtered_v_battery_ <= 0.0f) {
        filtered_v_battery_ = msg->v_battery;     // bootstrap, no startup dip
    } else {
        filtered_v_battery_ = 0.95f * filtered_v_battery_ + 0.05f * msg->v_battery;
    }
}
// battery_percent now derived from filtered_v_battery_ instead of msg->v_battery
```

Effect: 200–500 ms motor-startup load dips are absorbed, but a genuine discharge over minutes is tracked accurately. NeedsDocking trip behaviour is unchanged for true low-battery; the false-trip on transients is eliminated.

Bootstrap on first valid sample (no cold-start dip from zero), ignore samples below 10 V (sensor glitch / disconnected pack — keep the running average instead of crashing it).

No new parameters — alpha and the sanity floor are internal `constexpr` tuning. The defaults are appropriate for the live `/hardware_bridge/power` topic frequency; if that ever changes substantially, this needs revisiting.

## Test plan

- [x] Built cleanly (only pre-existing clangd ROS-header warnings).
- [ ] Pi5 verification: charge to full, expect GUI to read 100 % at ~28.0 V (was capped at 89 %).
- [ ] Pi5 verification: trigger a mow with motors fully loaded, confirm `battery_percent` does not transient-dip below the NeedsDocking threshold for as long as the no-load rail is well above it.
- [ ] Long-duration mow, confirm NeedsDocking still fires when battery is genuinely discharged (not just delayed forever by the filter).

## Related observations

- Operators who already overrode `battery_full_voltage` in their config are unaffected.
- The filter is BT-side only. The GUI's frontend fallback in `battery.ts` is unchanged because the GUI prefers `highLevelStatus.battery_percent` (which is the BT's filtered value) when available.
- A more aggressive option would be hysteresis at the BT condition layer (e.g. `NeedsDocking` requires the threshold crossing for N consecutive ticks). Skipped here — the low-pass filter is the simpler equivalent and lives at the right architectural layer (raw sensor cleanup before any BT logic sees it).