### PR TITLE
fix(gui): GPS RTK status mismatch + LiDAR toggle key (#24, #25)

### DIFF
--- a/gui/web/src/components/GpsComponent.tsx
+++ b/gui/web/src/components/GpsComponent.tsx
@@ -1,6 +1,6 @@
 import {Col, Row, Statistic} from "antd";
 import {useGPS} from "../hooks/useGPS.ts";
-import { booleanFormatter, booleanFormatterInverted } from "./utils.tsx";
+import { booleanFormatter, booleanFormatterInverted, gpsFixTypeLabel } from "./utils.tsx";
 import { AbsolutePoseConstants as Flags } from "../types/ros.ts";
 import {useThemeMode} from "../theme/ThemeContext.tsx";
 
@@ -11,14 +11,7 @@ export function GpsComponent() {
     const flags = gps.flags ?? 0;
     // RTK is active when FIXED or FLOAT bit is set (not just the base RTK/GPS-fix bit)
     const hasRtk = !!((flags & Flags.FLAG_GPS_RTK_FIXED) || (flags & Flags.FLAG_GPS_RTK_FLOAT));
-    let fixType = "\u2013";
-    if ((flags & Flags.FLAG_GPS_RTK_FIXED) != 0) {
-        fixType = "RTK FIX";
-    } else if ((flags & Flags.FLAG_GPS_RTK_FLOAT) != 0) {
-        fixType = "RTK FLOAT";
-    } else if ((flags & Flags.FLAG_GPS_RTK) != 0) {
-        fixType = "GPS FIX";
-    }
+    const fixType = gpsFixTypeLabel(flags);
 
     return <>
         <Row gutter={[16, 16]}>

--- a/gui/web/src/components/settings/SensorsSection.tsx
+++ b/gui/web/src/components/settings/SensorsSection.tsx
@@ -26,8 +26,8 @@ export const SensorsSection: React.FC<Props> = ({ values, onChange }) => {
                         </Paragraph>
                     </div>
                     <Switch
-                        checked={values.use_lidar ?? false}
-                        onChange={(v) => onChange("use_lidar", v)}
+                        checked={values.lidar_enabled ?? false}
+                        onChange={(v) => onChange("lidar_enabled", v)}
                     />
                 </div>
             </Card>

--- a/gui/web/src/components/utils.tsx
+++ b/gui/web/src/components/utils.tsx
@@ -1,6 +1,26 @@
 import {CheckCircleTwoTone, CloseCircleTwoTone} from "@ant-design/icons";
 import {Progress} from "antd";
 import {COLORS} from "../theme/colors.ts";
+import {AbsolutePoseConstants as Flags} from "../types/ros.ts";
+
+// Single source of truth for the GPS fix-type string. All UI surfaces (GPS card,
+// dashboard hint, diagnostics) MUST go through this helper so the dashboard never
+// shows "RTK float" while the diagnostics panel shows "RTK FIX" again.
+export const gpsFixTypeLabel = (flags: number | null | undefined): string => {
+    const f = flags ?? 0;
+    if (f & Flags.FLAG_GPS_RTK_FIXED) return "RTK FIX";
+    if (f & Flags.FLAG_GPS_RTK_FLOAT) return "RTK FLOAT";
+    if (f & Flags.FLAG_GPS_RTK) return "GPS FIX";
+    return "No Fix";
+};
+
+export const gpsFixTypeHint = (flags: number | null | undefined): string => {
+    const f = flags ?? 0;
+    if (f & Flags.FLAG_GPS_RTK_FIXED) return "RTK fixed";
+    if (f & Flags.FLAG_GPS_RTK_FLOAT) return "RTK float";
+    if (f & Flags.FLAG_GPS_RTK) return "GPS fix";
+    return "No GPS";
+};
 
 export const booleanFormatter = (value: any) => (value === "On" || value === "Yes") ?
     <CheckCircleTwoTone twoToneColor={COLORS.primary}/> : <CloseCircleTwoTone

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -55,7 +55,7 @@ const SECTION_DEFINITIONS: SectionMeta[] = [
             "lidar_enabled", "lidar_x", "lidar_y", "lidar_z", "lidar_yaw",
             "imu_x", "imu_y", "imu_z", "imu_yaw", "imu_pitch", "imu_roll",
             "gps_x", "gps_y", "gps_z",
-            "use_lidar", "dock_pose_yaw",
+            "dock_pose_yaw",
         ],
     },
     {

--- a/gui/web/src/pages/DiagnosticsPage.tsx
+++ b/gui/web/src/pages/DiagnosticsPage.tsx
@@ -37,10 +37,10 @@ import {useDiagnosticsSnapshot} from "../hooks/useDiagnosticsSnapshot.ts";
 import {useDiagnostics} from "../hooks/useDiagnostics.ts";
 import {useThemeMode} from "../theme/ThemeContext.tsx";
 import {useIsMobile} from "../hooks/useIsMobile";
-import {AbsolutePoseConstants} from "../types/ros.ts";
 import {useMemo} from "react";
 import {useSettings} from "../hooks/useSettings.ts";
 import {computeBatteryPercent} from "../utils/battery.ts";
+import {gpsFixTypeLabel} from "../components/utils.tsx";
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
@@ -107,12 +107,7 @@ export const DiagnosticsPage = () => {
     );
 
     const gpsFlags = gps.flags ?? 0;
-    const gpsFixType = useMemo(() => {
-        if (gpsFlags & AbsolutePoseConstants.FLAG_GPS_RTK_FIXED) return "RTK FIX";
-        if (gpsFlags & AbsolutePoseConstants.FLAG_GPS_RTK_FLOAT) return "RTK FLOAT";
-        if (gpsFlags & AbsolutePoseConstants.FLAG_GPS_RTK) return "GPS FIX";
-        return "No Fix";
-    }, [gpsFlags]);
+    const gpsFixType = useMemo(() => gpsFixTypeLabel(gpsFlags), [gpsFlags]);
 
     const orientation = pose.pose?.pose?.orientation;
     const qx = orientation?.x ?? 0;

--- a/gui/web/src/pages/MowgliNextPage.tsx
+++ b/gui/web/src/pages/MowgliNextPage.tsx
@@ -19,6 +19,7 @@ import {ImuComponent} from "../components/ImuComponent.tsx";
 import {GpsComponent} from "../components/GpsComponent.tsx";
 import {WheelTicksComponent} from "../components/WheelTicksComponent.tsx";
 import {SystemInfoComponent} from "../components/SystemInfoComponent.tsx";
+import {gpsFixTypeHint} from "../components/utils.tsx";
 
 function useMowerData() {
   const {highLevelStatus} = useHighLevelStatus();
@@ -67,6 +68,7 @@ function useMowerData() {
     charging: isCharging,
     emergency: isEmergency,
     gps: gpsQuality,
+    gpsFlags: gps.flags ?? 0,
     vBattery: power.v_battery ?? 0,
     current: power.charge_current ?? 0,
     rpm: status.mower_motor_rpm ?? 0,
@@ -117,12 +119,11 @@ export const MowgliNextPage = () => {
     currentArea: data.currentArea,
   };
 
-  const gpsHint = (() => {
-    if (data.gps >= 100) return 'RTK fixed';
-    if (data.gps >= 50) return 'RTK float';
-    if (data.gps > 0) return 'GPS fix';
-    return 'No GPS';
-  })();
+  // Always derive the hint from the authoritative AbsolutePose flags, never from
+  // the gps_quality_percent number — that one is a heuristic (HDOP-derived) and
+  // would round 60-99 % down to "RTK float" while the device is actually FIXED.
+  // See issue #24.
+  const gpsHint = gpsFixTypeHint(data.gpsFlags);
 
   if (isMobile) {
     return (


### PR DESCRIPTION
## Summary

Two GUI bugs caused by display paths being decoupled from the live source-of-truth.

### #24 — GPS RTK status mismatch across dashboard

- Top GPS card subtitle and Health-check both showed `RTK float` while the Sensors panel showed `RTK FIX` for the same fix.
- Root cause: card / health-check derived their hint from `data.gps` — a number from `highLevelStatus.gps_quality_percent` (heuristic, HDOP-derived). A real RTK FIX scoring 60–99 % in the heuristic mapped to `>= 50 → "RTK float"`. Sensors panel reads `AbsolutePose.flags` directly and was correct.
- Fix: extract `gpsFixTypeLabel(flags)` / `gpsFixTypeHint(flags)` helpers in `components/utils.tsx`. Route GpsComponent, MowgliNextPage hint and DiagnosticsPage through them. The percent number stays for the trail/tile, but never for the human-readable status string.

### #25 — LiDAR Sensor toggle bound to wrong key

- Settings → Sensors → LiDAR Sensor toggle showed OFF while K-ICP and the LD19 driver were running.
- Root cause: toggle read/wrote `values.use_lidar`, but `mowgli_robot.yaml` uses `lidar_enabled`. Toggling would also persist `use_lidar=true` into the yaml, which nothing on the ROS2 side reads.
- Fix: bind the Switch to `values.lidar_enabled` and drop the stray `use_lidar` from the sensors-keys whitelist in `useSettingsManager.ts`.

## Files

| Issue | File |
|---|---|
| #24 | `components/utils.tsx` (helpers) |
| #24 | `components/GpsComponent.tsx` |
| #24 | `pages/MowgliNextPage.tsx` |
| #24 | `pages/DiagnosticsPage.tsx` |
| #25 | `components/settings/SensorsSection.tsx` |
| #25 | `hooks/useSettingsManager.ts` |

`tsc --noEmit` clean locally.

## Test plan

**Needs Pi5 verify before merge.**

- [ ] Pull `:dev` image after CI builds, `mowgli-restart gui`
- [ ] Open dashboard. With current RTK-Fixed state, **GPS card subtitle**, **Health-check `GPS signal` row** and **Sensors → GPS → Fix type** all read `RTK fixed`/`RTK FIX` consistently. With RTK-Float, they all read `RTK float`/`RTK FLOAT`. With no GPS, all read `No GPS`/`No Fix`.
- [ ] Open Settings → Sensors. While `lidar_enabled: true` is in `mowgli_robot.yaml` and `ros2 node list | grep kinematic` shows K-ICP nodes alive, the LiDAR Sensor toggle is **ON**.
- [ ] Toggle off → save → confirm `lidar_enabled: false` lands in the yaml (NOT a new `use_lidar: false` key).