### PR TITLE
chore(gui): remove Beamer changelog widget

### DIFF
--- a/gui/web/index.html
+++ b/gui/web/index.html
@@ -15,9 +15,6 @@
           type="text/css">
     <title>MowgliNext</title>
 <style>
-    @media (max-width: 767px) {
-        .beamer_defaultBeamerSelector { display: none !important; }
-    }
     body {
         margin: 0;
         padding: 0;
@@ -39,11 +36,5 @@
 <body>
 <div id="root"></div>
 <script type="module" src="/src/main.tsx"></script>
-<script>
-    var beamer_config = {
-        product_id: 'dRSYRRqK59491',
-    };
-</script>
-<script type="text/javascript" src="https://app.getbeamer.com/js/beamer-embed.js" defer="defer"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Drop the Beamer (\"what's new\") embed from the web GUI:

- `<script>var beamer_config = { product_id: '…' };</script>` — config
- `<script src=\"https://app.getbeamer.com/js/beamer-embed.js\" defer></script>` — embed
- `@media (max-width: 767px) { .beamer_defaultBeamerSelector { display: none !important; } }` — the mobile-hide-CSS that propped it up

The widget injected a bell button in the bottom-right corner of the GUI. We don't want that surface and have no plan to relocate the changelog feature. Release notes live in the GitHub repo.

## Files

- `gui/web/index.html` — 9 lines removed, no replacement

## Test plan

- [ ] Pull `:dev` image after CI builds, `mowgli-restart gui`
- [ ] Open the GUI on desktop and mobile — no bell icon in the bottom-right corner
- [ ] DevTools network tab shows no request to `app.getbeamer.com`