### PR TITLE
feat(localization): pause LiDAR + K-ICP lifecycle while charging (#29 layer 1)

### DIFF
--- a/ros2/src/mowgli_bringup/launch/kinematic_icp.launch.py
+++ b/ros2/src/mowgli_bringup/launch/kinematic_icp.launch.py
@@ -163,6 +163,28 @@ def generate_launch_description() -> LaunchDescription:
         ],
     )
 
+    # ------------------------------------------------------------------
+    # 5. Charging-aware lifecycle coordinator (issue #29 Layer 1).
+    #    Listens to /hardware_bridge/status; when is_charging stays true
+    #    for >= debounce, calls lifecycle DEACTIVATE on ldlidar_node and
+    #    on this kinematic_icp_online_node so the LD19 driver and the
+    #    ICP main loop stop drawing CPU on the dock. Reactivates the
+    #    moment is_charging clears (no debounce — wake before undock).
+    #    Layer 2 (LD19 motor PWM control) lives in a follow-up node and
+    #    needs hardware wiring; this is software-only.
+    # ------------------------------------------------------------------
+    charging_coordinator = Node(
+        package="mowgli_localization",
+        executable="charging_lidar_coordinator.py",
+        name="charging_lidar_coordinator",
+        output="screen",
+        parameters=[
+            {
+                "use_sim_time": use_sim_time,
+            }
+        ],
+    )
+
     return LaunchDescription(
         [
             use_sim_time_arg,
@@ -170,5 +192,6 @@ def generate_launch_description() -> LaunchDescription:
             scan_relay,
             kinematic_icp_node,
             kicp_encoder_adapter,
+            charging_coordinator,
         ]
     )

--- a/ros2/src/mowgli_localization/CMakeLists.txt
+++ b/ros2/src/mowgli_localization/CMakeLists.txt
@@ -149,6 +149,7 @@ install(
 # Python nodes (installed executable, run via `ros2 run mowgli_localization ...`)
 install(
   PROGRAMS
+    scripts/charging_lidar_coordinator.py
     scripts/kinematic_icp_encoder_adapter.py
     scripts/kinematic_icp_scan_frame_relay.py
     scripts/wheel_odom_tf_node.py

--- a/ros2/src/mowgli_localization/scripts/charging_lidar_coordinator.py
+++ b/ros2/src/mowgli_localization/scripts/charging_lidar_coordinator.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""charging_lidar_coordinator.py
+
+Issue #29 Layer 1: software-side CPU savings while charging on the dock.
+
+Subscribes /hardware_bridge/status (mowgli_interfaces/msg/Status). On stable
+is_charging=true (>= charging_debounce_sec), calls lifecycle DEACTIVATE on
+ldlidar_node and on kinematic_icp_online_node so the LD19 serial driver and
+the ICP main loop stop consuming CPU. On is_charging=false the activation is
+immediate (no debounce — wake before undock).
+
+Layer 2 (LD19 motor PWM control via Pi5 GPIO) is intentionally NOT here —
+see the #29 issue body and the open follow-up. This node is software-only
+and works on any install regardless of GPIO wiring.
+
+Failsafe: if a lifecycle service is unavailable (use_lidar=false, the LiDAR
+stack is not running, or a node hasn't reached active state yet) the call
+is logged as a warning and skipped — the mower keeps working as today.
+"""
+
+import rclpy
+from rclpy.node import Node
+from lifecycle_msgs.msg import Transition
+from lifecycle_msgs.srv import ChangeState
+from mowgli_interfaces.msg import Status
+
+
+class ChargingLidarCoordinator(Node):
+    def __init__(self) -> None:
+        super().__init__("charging_lidar_coordinator")
+
+        self.declare_parameter("enabled", True)
+        self.declare_parameter("charging_debounce_sec", 5.0)
+        self.declare_parameter("status_topic", "/hardware_bridge/status")
+        self.declare_parameter(
+            "lidar_lifecycle_service", "/ldlidar_node/change_state")
+        self.declare_parameter(
+            "kicp_lifecycle_service",
+            "/kinematic_icp/kinematic_icp_online_node/change_state")
+        self.declare_parameter("service_call_timeout_sec", 2.0)
+
+        self._enabled = bool(self.get_parameter("enabled").value)
+        self._debounce_sec = float(
+            self.get_parameter("charging_debounce_sec").value)
+        self._status_topic = str(self.get_parameter("status_topic").value)
+        self._lidar_svc_name = str(
+            self.get_parameter("lidar_lifecycle_service").value)
+        self._kicp_svc_name = str(
+            self.get_parameter("kicp_lifecycle_service").value)
+        self._svc_timeout = float(
+            self.get_parameter("service_call_timeout_sec").value)
+
+        self._last_charging = False
+        self._charging_since = None
+        self._currently_paused = False
+
+        self._lidar_client = self.create_client(
+            ChangeState, self._lidar_svc_name)
+        self._kicp_client = self.create_client(
+            ChangeState, self._kicp_svc_name)
+
+        self._status_sub = self.create_subscription(
+            Status, self._status_topic, self._on_status, 10)
+
+        if not self._enabled:
+            self.get_logger().info(
+                "ChargingLidarCoordinator disabled via parameter")
+        else:
+            self.get_logger().info(
+                "ChargingLidarCoordinator active: debounce=%.1fs, "
+                "lidar=%s, kicp=%s",
+                self._debounce_sec,
+                self._lidar_svc_name,
+                self._kicp_svc_name,
+            )
+
+    def _on_status(self, msg: Status) -> None:
+        if not self._enabled:
+            return
+
+        now = self.get_clock().now()
+        is_charging = bool(msg.is_charging)
+
+        if is_charging and not self._last_charging:
+            self._charging_since = now
+            self.get_logger().info(
+                "Charging started — will pause LiDAR+K-ICP after %.1fs "
+                "of stable charging",
+                self._debounce_sec,
+            )
+
+        elif not is_charging and self._last_charging:
+            self._charging_since = None
+            if self._currently_paused:
+                self._set_paused(False)
+
+        elif (is_charging
+              and self._charging_since is not None
+              and not self._currently_paused):
+            elapsed = (now - self._charging_since).nanoseconds / 1e9
+            if elapsed >= self._debounce_sec:
+                self._set_paused(True)
+                self._charging_since = None
+
+        self._last_charging = is_charging
+
+    def _set_paused(self, pause: bool) -> None:
+        transition_id = (Transition.TRANSITION_DEACTIVATE if pause
+                         else Transition.TRANSITION_ACTIVATE)
+        verb = "DEACTIVATE" if pause else "ACTIVATE"
+
+        for client, label in (
+            (self._lidar_client, "ldlidar_node"),
+            (self._kicp_client, "kinematic_icp_online_node"),
+        ):
+            if not client.wait_for_service(timeout_sec=self._svc_timeout):
+                self.get_logger().warning(
+                    "%s lifecycle service unavailable — skipping %s",
+                    label, verb,
+                )
+                continue
+            req = ChangeState.Request()
+            req.transition.id = transition_id
+            future = client.call_async(req)
+            future.add_done_callback(
+                lambda fut, lbl=label, vrb=verb:
+                self._on_change_done(fut, lbl, vrb))
+
+        self._currently_paused = pause
+        self.get_logger().info(
+            "LiDAR+K-ICP %s requested (%s)",
+            verb,
+            "charging stable" if pause else "charging cleared",
+        )
+
+    def _on_change_done(
+            self, future, node_label: str, verb: str) -> None:
+        try:
+            resp = future.result()
+        except Exception as exc:
+            self.get_logger().error(
+                "%s %s failed: %s", node_label, verb, exc)
+            return
+        if resp.success:
+            self.get_logger().info("%s %s OK", node_label, verb)
+        else:
+            self.get_logger().warning(
+                "%s %s returned success=false (likely already in target state)",
+                node_label, verb,
+            )
+
+
+def main() -> None:
+    rclpy.init()
+    node = ChargingLidarCoordinator()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Layer 1 of #29: software-side CPU savings by lifecycle-deactivating the LiDAR + Kinematic-ICP stack while the mower is charging. Layer 2 (LD19 motor PWM control via Pi5 GPIO) is intentionally **out of scope** for this PR — it needs hardware wiring and boot-config changes; tracked as a follow-up on #29.

### What it does

New small Python node \`charging_lidar_coordinator.py\` (in \`mowgli_localization\`):

- Subscribes \`/hardware_bridge/status\` (\`mowgli_interfaces/msg/Status\`)
- On stable \`is_charging=true\` for ≥ \`charging_debounce_sec\` (default 5 s): calls lifecycle DEACTIVATE on \`/ldlidar_node\` and \`/kinematic_icp/kinematic_icp_online_node\`
- On \`is_charging=false\`: immediately calls lifecycle ACTIVATE on both (no debounce — wake before the BT can undock)
- Wired into \`kinematic_icp.launch.py\` so it only runs when \`use_lidar=true\`

### What it does NOT touch (per issue body)

- RTK lock / NTRIP / GPS — UM980 reacquisition is minutes
- IMU bias calibration in \`hardware_bridge_node\` — runs every dock arrival, must stay alive
- Nav2 lifecycle + FusionCore — designed for always-on
- BehaviorTree — needs to keep ticking for COMMAND_START + auto-reset-emergency

### Failsafe

\`wait_for_service(timeout=2s)\` per lifecycle endpoint. If unavailable (\`use_lidar=false\`, K-ICP not up, etc.) the call is logged as warning and skipped — node degrades to a no-op, mower keeps working as today.

If lifecycle returns \`success=false\` (already in target state, e.g. activate-from-active), it's a warning, not an error. Robust to repeated charging transitions.

## Files

- \`ros2/src/mowgli_localization/scripts/charging_lidar_coordinator.py\` (new, +166 LoC, executable)
- \`ros2/src/mowgli_localization/CMakeLists.txt\` (add to \`install(PROGRAMS …)\`)
- \`ros2/src/mowgli_bringup/launch/kinematic_icp.launch.py\` (add Node entry to LaunchDescription)

## Test plan (Pi5)

- [ ] After deploy + container restart, with mower on dock and charging:
  - After ~5 s, logs show \`ldlidar_node DEACTIVATE OK\` and \`kinematic_icp_online_node DEACTIVATE OK\`
  - \`/scan\` topic stops publishing (\`ros2 topic hz /scan\` shows no messages)
  - CPU on Pi5 measurably drops (\`htop\` or \`docker stats mowgli-ros2 mowgli-lidar\`); target 30-50% reduction per issue body
- [ ] Undock the mower (carry off the dock or COMMAND_HOME-then-undock):
  - Within ~1 s of \`is_charging=false\`, logs show ACTIVATE OK for both
  - \`/scan\` resumes
  - \`/kinematic_icp/lidar_odometry\` resumes
- [ ] One full cycle: COMMAND_START from dock → undock → transit → mow → COMMAND_HOME → dock again. Verify clean handoff in both directions.
- [ ] Verify FusionCore / RTK is unaffected — \`/fusion/odom\` keeps publishing through dock arrival, \`/gps/fix\` stays Fixed/Float, no Mahalanobis spam.

## Layer 2 follow-up

LD19 motor PWM control still needs:
- GPIO 18 ↔ LD19 PWM pin wiring on the Pi5
- \`dtoverlay=pwm,pin=18,func=2\` in \`/boot/firmware/config.txt\`
- \`lidar_pwm_node\` (sysfs PWM driver, ~200 LoC C++)
- systemd boot-init service so the LD19 sees a valid PWM signal from power-on (failsafe against controller crash)

To be done as a separate PR once the wiring is in place. The current PR is the software half and brings real CPU savings on its own.