### PR TITLE
chore(gps-nmea): add str2str silent-stall watchdog (#40)

### DIFF
--- a/sensors/gps-nmea/start_gps_nmea.sh
+++ b/sensors/gps-nmea/start_gps_nmea.sh
@@ -72,15 +72,43 @@ DRIVER_PID=$!
 
 # 3. NTRIP via str2str — pulls RTCM3 from the caster, writes it to the GPS
 #    serial device. Multi-opener safe on Linux CDC.
+#
+# Issue #40: str2str sometimes silently stalls after long uptime — TCP socket
+# stays connected ([CC---]) but throughput collapses to ~0 bps. RTK on the
+# rover degrades and a manual `mowgli-restart gps` is the only fix.
+#
+# str2str's stderr already emits a per-5s status line:
+#   2026/04/26 14:05:21 [CC---]   163090 B   15313 bps (0) host/mountpoint
+# Capture it to a log so a watchdog loop can read the cumulative byte counter
+# and detect stalls. Mirror the same line to the docker logs (>&2) so the
+# existing visibility through `docker logs mowgli-gps` is preserved.
+
 STR2STR_PID=0
+STR2STR_LOG=/tmp/str2str.log
+
+# Watchdog tuning (env-overridable). Byte-counter based: more reliable than
+# parsing the per-tick bps column which legitimately shows 0 between RTCM
+# bursts. Threshold default 60 s of zero growth while [CC---] = stuck.
+WATCHDOG_ENABLED="${NTRIP_WATCHDOG_ENABLED:-true}"
+WATCHDOG_INTERVAL_SEC="${NTRIP_WATCHDOG_INTERVAL_SEC:-10}"
+WATCHDOG_STUCK_TIMEOUT_SEC="${NTRIP_WATCHDOG_STUCK_TIMEOUT_SEC:-60}"
+WATCHDOG_PID=0
+
 start_str2str() {
   [ "$NTRIP_ENABLED" = "true" ] || return
   [ -n "${NTRIP_HOST:-}" ] && [ -n "${NTRIP_MOUNT:-}" ] || {
     echo "[gps-nmea] NTRIP enabled but host/mountpoint missing"; return; }
   echo "[gps-nmea] NTRIP -> ${NTRIP_HOST}:${NTRIP_PORT}/${NTRIP_MOUNT} -> ${GPS_PORT}"
+  # Truncate the log on every (re)start so the watchdog's byte counter
+  # baseline starts from zero. Tail-following (`tail -n0 -F`) survives
+  # truncate via inotify, but resetting the file keeps the log small.
+  : > "$STR2STR_LOG"
+  # Process substitution: stderr → tee → log file + mirrored to docker stderr.
+  # str2str's status lines are line-buffered already (printf to stderr).
   str2str \
     -in "ntrip://${NTRIP_USER}:${NTRIP_PASS}@${NTRIP_HOST}:${NTRIP_PORT}/${NTRIP_MOUNT}" \
-    -out "file://${GPS_PORT}" &
+    -out "file://${GPS_PORT}" \
+    2> >(tee -a "$STR2STR_LOG" >&2) &
   STR2STR_PID=$!
 }
 
@@ -93,7 +121,46 @@ stop_str2str() {
   STR2STR_PID=0
 }
 
+# Watchdog: poll the str2str log periodically, parse the cumulative byte
+# counter from the latest [CC---] (connected) status line. If the counter
+# does not advance for >= STUCK_TIMEOUT_SEC, the connection is stuck —
+# restart str2str. [WC---] (timeout/disconnect) lines are ignored: str2str
+# already self-recovers from honest disconnects; we only watch for the
+# silent-stall failure mode where TCP stays up but no RTCM flows.
+ntrip_watchdog() {
+  local last_bytes=-1
+  local last_change_ts
+  last_change_ts=$(date +%s)
+  while sleep "$WATCHDOG_INTERVAL_SEC"; do
+    [ "${STR2STR_PID:-0}" -gt 0 ] || continue
+    kill -0 "$STR2STR_PID" 2>/dev/null || continue
+    local line
+    line=$(grep -E "^[0-9/]+ [0-9:]+ \[CC[-]+\]" "$STR2STR_LOG" 2>/dev/null | tail -1)
+    [ -n "$line" ] || continue
+    local bytes
+    bytes=$(awk '{print $4}' <<<"$line")
+    [[ "$bytes" =~ ^[0-9]+$ ]] || continue
+    local now
+    now=$(date +%s)
+    if [ "$bytes" != "$last_bytes" ]; then
+      last_bytes=$bytes
+      last_change_ts=$now
+      continue
+    fi
+    local stuck_for=$((now - last_change_ts))
+    if [ "$stuck_for" -ge "$WATCHDOG_STUCK_TIMEOUT_SEC" ]; then
+      echo "[gps-nmea] watchdog: str2str connected but byte counter stuck at $bytes for ${stuck_for}s — restarting"
+      stop_str2str
+      sleep 2
+      start_str2str
+      last_bytes=-1
+      last_change_ts=$(date +%s)
+    fi
+  done
+}
+
 cleanup() {
+  [ "${WATCHDOG_PID:-0}" -gt 0 ] && kill "${WATCHDOG_PID}" 2>/dev/null || true
   stop_str2str
   kill "${DRIVER_PID}" "${BRIDGE_PID}" 2>/dev/null || true
   exit 0
@@ -103,6 +170,14 @@ trap cleanup TERM INT
 # Give the bridge a beat to open the serial device before NTRIP starts writing.
 sleep 3
 start_str2str
+
+# Watchdog: detect silent str2str stalls (#40) and restart in place. Disabled
+# trivially via NTRIP_WATCHDOG_ENABLED=false at container start.
+if [ "$NTRIP_ENABLED" = "true" ] && [ "$WATCHDOG_ENABLED" = "true" ]; then
+  echo "[gps-nmea] NTRIP watchdog: poll=${WATCHDOG_INTERVAL_SEC}s stuck-timeout=${WATCHDOG_STUCK_TIMEOUT_SEC}s"
+  ntrip_watchdog &
+  WATCHDOG_PID=$!
+fi
 
 # Hot-reload NTRIP on config changes (so users editing the YAML via the GUI
 # don't need to restart the container).


### PR DESCRIPTION
## Summary

Closes #40. Adds an in-container bash watchdog around \`str2str\` that detects the silent-stall failure mode (TCP connected, throughput collapsed) and restarts the process in place — same effect as a manual \`mowgli-restart gps\`, no operator action required.

### How it works

\`str2str\` already emits a per-5-second status line on stderr:
\`\`\`
2026/04/26 14:05:21 [CC---]   163090 B   15313 bps (0) 10.10.40.251/Eichenau
\`\`\`

In \`start_str2str()\`:
- stderr is piped through \`tee\` into \`/tmp/str2str.log\` and mirrored back to the docker stderr (existing \`docker logs mowgli-gps\` output is unchanged)
- the log is truncated on every (re)start so the watchdog baselines from zero

The watchdog (\`ntrip_watchdog\` background loop):
- every \`NTRIP_WATCHDOG_INTERVAL_SEC\` (default 10 s) reads the latest \`[CC---]\` (connected) line, parses the cumulative byte counter (field 4)
- if the counter doesn't advance for \`NTRIP_WATCHDOG_STUCK_TIMEOUT_SEC\` (default 60 s), calls \`stop_str2str\` + \`start_str2str\`
- ignores \`[WC---]\` (genuine timeouts/disconnects) — str2str already self-recovers from those; we only catch the silent-stall case where TCP stays up but no RTCM flows

### Why byte-counter not bps

The \`bps\` column legitimately shows \`0\` on individual ticks during normal operation (RTCM corrections come in bursts, not continuously). Polling the cumulative \`B\` counter is more robust against false positives.

### No flapping

After a watchdog-triggered restart, the baseline (\`last_bytes=-1\`, fresh timestamp) is reset, so the watchdog waits another full \`STUCK_TIMEOUT_SEC\` window before it could fire again. If the stall genuinely persists (e.g. NTRIP base actually offline), the script restarts every ~70 s — visible and bounded.

### Tunables (env-overridable)

| var | default | purpose |
|-----|---------|---------|
| \`NTRIP_WATCHDOG_ENABLED\` | \`true\` | kill switch |
| \`NTRIP_WATCHDOG_INTERVAL_SEC\` | \`10\` | poll cadence |
| \`NTRIP_WATCHDOG_STUCK_TIMEOUT_SEC\` | \`60\` | how long zero growth = stuck |

## Files

- \`sensors/gps-nmea/start_gps_nmea.sh\` — +76 / -1 (new functions \`ntrip_watchdog\`, watchdog start at end, stderr capture in \`start_str2str\`, kill in \`cleanup\`)

## Test plan (Pi5)

- [ ] Healthy stream: deploy, leave running, no \`watchdog: ... restarting\` line should appear in \`docker logs mowgli-gps\`
- [ ] Force a stall (DROP TCP from inside container): \`docker exec mowgli-gps iptables -A OUTPUT -p tcp --dport 2101 -j DROP\` (or via host \`sudo iptables -A FORWARD -p tcp --dport 2101 -d 10.10.40.251 -j DROP\`). Watch logs for the watchdog detecting after ~70 s and triggering a restart. Revert iptables; healthy stream resumes within seconds.
- [ ] Long-uptime: leave running for >15 h and confirm the originally-observed silent-stall is now self-healed without manual intervention.

## Notes

This is the in-container fix. It does not address the upstream RTKLib \`str2str\` bug (whatever causes the half-open-style stall in the first place); the issue body in #40 lists possible causes and a longer-term option to swap str2str for a more robust NTRIP client. This watchdog is the cheap and immediate operational fix.