### PR TITLE
fix(localization): rclpy logger takes a string, not printf args (#29)

### DIFF
--- a/ros2/src/mowgli_localization/scripts/charging_lidar_coordinator.py
+++ b/ros2/src/mowgli_localization/scripts/charging_lidar_coordinator.py
@@ -67,11 +67,10 @@ class ChargingLidarCoordinator(Node):
                 "ChargingLidarCoordinator disabled via parameter")
         else:
             self.get_logger().info(
-                "ChargingLidarCoordinator active: debounce=%.1fs, "
-                "lidar=%s, kicp=%s",
-                self._debounce_sec,
-                self._lidar_svc_name,
-                self._kicp_svc_name,
+                f"ChargingLidarCoordinator active: "
+                f"debounce={self._debounce_sec:.1f}s, "
+                f"lidar={self._lidar_svc_name}, "
+                f"kicp={self._kicp_svc_name}"
             )
 
     def _on_status(self, msg: Status) -> None:
@@ -84,9 +83,8 @@ class ChargingLidarCoordinator(Node):
         if is_charging and not self._last_charging:
             self._charging_since = now
             self.get_logger().info(
-                "Charging started — will pause LiDAR+K-ICP after %.1fs "
-                "of stable charging",
-                self._debounce_sec,
+                f"Charging started — will pause LiDAR+K-ICP after "
+                f"{self._debounce_sec:.1f}s of stable charging"
             )
 
         elif not is_charging and self._last_charging:
@@ -115,8 +113,8 @@ class ChargingLidarCoordinator(Node):
         ):
             if not client.wait_for_service(timeout_sec=self._svc_timeout):
                 self.get_logger().warning(
-                    "%s lifecycle service unavailable — skipping %s",
-                    label, verb,
+                    f"{label} lifecycle service unavailable "
+                    f"(not lifecycle, or stack down) — skipping {verb}"
                 )
                 continue
             req = ChangeState.Request()
@@ -127,10 +125,9 @@ class ChargingLidarCoordinator(Node):
                 self._on_change_done(fut, lbl, vrb))
 
         self._currently_paused = pause
+        reason = "charging stable" if pause else "charging cleared"
         self.get_logger().info(
-            "LiDAR+K-ICP %s requested (%s)",
-            verb,
-            "charging stable" if pause else "charging cleared",
+            f"LiDAR+K-ICP {verb} requested ({reason})"
         )
 
     def _on_change_done(
@@ -139,14 +136,14 @@ class ChargingLidarCoordinator(Node):
             resp = future.result()
         except Exception as exc:
             self.get_logger().error(
-                "%s %s failed: %s", node_label, verb, exc)
+                f"{node_label} {verb} failed: {exc}")
             return
         if resp.success:
-            self.get_logger().info("%s %s OK", node_label, verb)
+            self.get_logger().info(f"{node_label} {verb} OK")
         else:
             self.get_logger().warning(
-                "%s %s returned success=false (likely already in target state)",
-                node_label, verb,
+                f"{node_label} {verb} returned success=false "
+                "(likely already in target state)"
             )
 
 


### PR DESCRIPTION
## Summary

Hotfix for PR #44 (issue #29 layer 1). The first live deploy on the Pi5 immediately crashed:

\`\`\`
TypeError: RcutilsLogger.info() takes 2 positional arguments but 5 were given
[ERROR] charging_lidar_coordinator.py: process has died [pid 48, exit code 1]
\`\`\`

Root cause: rclpy's logger is **not** rclcpp's. It does **not** accept printf-style varargs. All five log call sites in the coordinator were passing \`%s\`/\`%.1f\` format strings plus separate args. Switched to f-strings.

## What this changes vs the original

- \`get_logger().info(fmt, arg1, arg2)\` → \`get_logger().info(f"... {arg1} ... {arg2}")\` for all five call sites in the coordinator
- No behavioural change beyond \"the process actually starts\"

## Side note about K-ICP

\`ros2 lifecycle nodes\` on the live Pi5 only lists \`/ldlidar_node\` and the Nav2 + FusionCore stack. \`/kinematic_icp/kinematic_icp_online_node\` is **not** lifecycle-managed in our build (likely an upstream choice). So with this PR + #44 merged:

- \`ldlidar_node\` will be lifecycle-deactivated correctly when charging — saves the 9% CPU the LD19 driver was using on the Pi5
- \`kinematic_icp_online_node\` will hit the defensive \`wait_for_service\` timeout, log a warning, and continue — no crash, but no CPU saved on the K-ICP side either

That's a known limitation, not a bug. K-ICP CPU savings are a separate follow-up — either a kill+respawn shim, or an upstream PR to make \`kinematic_icp_online_node\` lifecycle.

## Test plan (re-run on Pi5 after merge)

- [ ] After deploy + container restart, with mower charging:
  - No more \`TypeError\` in \`docker logs mowgli-ros2\`
  - After ~5 s, log shows \`ldlidar_node DEACTIVATE OK\`
  - For K-ICP, log shows \`kinematic_icp_online_node lifecycle service unavailable — skipping DEACTIVATE\` (expected, see above)
  - mowgli-lidar CPU drops from ~9% to ~0%
- [ ] Undock: log shows \`ldlidar_node ACTIVATE OK\`, \`/scan\` resumes