### PR TITLE
Sync 6 upstream commits: BT redock, FTC tuning, K-ICP fixes, AUTONOMOUS state

### DIFF
--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -76,16 +76,18 @@
              drift on idle can falsely put the reported pose outside the
              polygon. No reason to run any boundary handler in that state. -->
         <IsCharging/>
-        <!-- Short-circuit during manual mowing (COMMAND_MANUAL_MOW = 7)
-             and area recording (COMMAND_RECORD_AREA = 3). In both modes
-             the operator is driving via joystick and is the authority
-             on where the robot can go — forcibly stopping with a
-             boundary emergency would lock the robot mid-recording and
-             ruin the session. The blade is still governed by firmware
-             safety, and collision_monitor still stops for physical
-             obstacles. -->
+        <!-- Short-circuit during manual mowing (COMMAND_MANUAL_MOW = 7),
+             area recording (COMMAND_RECORD_AREA = 3), and going home
+             (COMMAND_HOME = 2). In all three modes the destination is
+             expected to lie outside the mowing polygon (joystick area
+             for manual/record, dock for home), so a boundary handler
+             would fire spuriously and cancel DockRobot mid-approach,
+             which is what was breaking auto-redock. The blade is still
+             governed by firmware safety, and collision_monitor still
+             stops for physical obstacles. -->
         <IsCommand command="7"/>
         <IsCommand command="3"/>
+        <IsCommand command="2"/>
         <Inverter><IsBoundaryViolation/></Inverter>
 
         <!-- Lethal path: stop immediately, latch -->

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -163,7 +163,7 @@
           <IsBatteryLow threshold="10.0"/>
           <SetMowerEnabled enabled="false"/>
           <StopMoving/>
-          <PublishHighLevelStatus state="1" state_name="CRITICAL_BATTERY_DOCKING"/>
+          <PublishHighLevelStatus state="2" state_name="CRITICAL_BATTERY_DOCKING"/>
           <SaveObstacles/>
           <SaveSlamMap map_path="/ros2_ws/maps/garden_map"/>
           <Fallback name="CriticalNavOrStop">
@@ -335,7 +335,7 @@
                 <Sequence name="RainDockAndResume">
                   <SetMowerEnabled enabled="false"/>
                   <StopMoving/>
-                  <PublishHighLevelStatus state="1" state_name="RAIN_DETECTED_DOCKING"/>
+                  <PublishHighLevelStatus state="2" state_name="RAIN_DETECTED_DOCKING"/>
                   <SaveSlamMap map_path="/ros2_ws/maps/garden_map"/>
                   <Fallback name="RainNavOrStay">
                     <DockRobot dock_id="home_dock" dock_type="simple_charging_dock"/>
@@ -383,7 +383,7 @@
                 <Sequence name="BatteryDockAndResume">
                   <SetMowerEnabled enabled="false"/>
                   <StopMoving/>
-                  <PublishHighLevelStatus state="1" state_name="LOW_BATTERY_DOCKING"/>
+                  <PublishHighLevelStatus state="2" state_name="LOW_BATTERY_DOCKING"/>
                   <SaveSlamMap map_path="/ros2_ws/maps/garden_map"/>
                   <DockRobot dock_id="home_dock" dock_type="simple_charging_dock"/>
                   <PublishHighLevelStatus state="1" state_name="CHARGING"/>
@@ -477,7 +477,7 @@
             <Sequence name="FailedCoverageDock">
               <SetMowerEnabled enabled="false"/>
               <SaveSlamMap map_path="/ros2_ws/maps/garden_map"/>
-              <PublishHighLevelStatus state="1" state_name="COVERAGE_FAILED_DOCKING"/>
+              <PublishHighLevelStatus state="2" state_name="COVERAGE_FAILED_DOCKING"/>
               <Fallback name="FailedCoverageNavOrStop">
                 <DockRobot dock_id="home_dock" dock_type="simple_charging_dock"/>
                 <Sequence>
@@ -528,7 +528,7 @@
             <ReactiveFallback name="HomeOrAlreadyDocked">
               <IsCharging/>
               <Sequence name="NavigateHome">
-                <PublishHighLevelStatus state="1" state_name="RETURNING_HOME"/>
+                <PublishHighLevelStatus state="2" state_name="RETURNING_HOME"/>
                 <SaveObstacles/>
                 <SaveSlamMap map_path="/ros2_ws/maps/garden_map"/>
                 <Fallback name="HomeNavOrStop">

--- a/ros2/src/mowgli_bringup/config/kinematic_icp.yaml
+++ b/ros2/src/mowgli_bringup/config/kinematic_icp.yaml
@@ -41,16 +41,21 @@
     max_points_per_voxel: 5
 
     # Correspondence threshold — Kinematic-ICP's adaptive threshold scales
-    # ICP's max-correspondence distance with observed model error. Keep
-    # adaptive on; fixed_threshold is the fallback if disabled.
-    use_adaptive_threshold: true
-    fixed_threshold: 0.3
+    # ICP's max-correspondence distance with observed model error. The
+    # adaptive policy under-estimates during fast yaw on a sparse 2D scan
+    # (the LD19 has only ~1.7° of new content per frame at 17°/s rotation),
+    # which causes the registration to drop frames and freeze the K-ICP
+    # pose for ~1 s at a time. Force a permissive fixed window so every
+    # scan finds correspondences during rotation.
+    use_adaptive_threshold: false
+    fixed_threshold: 0.6
 
     # Registration
     # Kinematic-ICP uses far fewer ICP iterations than KISS-ICP because the
     # wheel-kinematic prior puts the initial guess very close to truth.
-    # 10 iterations × tighter convergence is typical upstream; keep defaults.
-    max_num_iterations: 10
+    # Bumped to 20 (from 10) so ICP can still converge under fast yaw when
+    # correspondences require more steps to settle.
+    max_num_iterations: 20
     convergence_criterion: 0.001
     # ARM is CPU-bound with Nav2 + FusionCore running; single-threaded ICP
     # is fine for 2D sparse clouds and leaves cores for controllers.

--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -150,26 +150,41 @@ controller_server:
       speed_fast: 0.5              # carrot speed when far from path (m/s)
       speed_fast_threshold: 0.5    # distance threshold for fast/slow (m)
       speed_fast_threshold_angle: 10.0  # angle threshold for fast (deg)
-      speed_slow: 0.3             # carrot speed when close/turning (m/s)
-      speed_angular: 60.0          # rotation speed for in-place turns (deg/s)
-      acceleration: 1.0            # carrot acceleration (m/s²) — higher to overcome grass
-      # PID longitudinal
-      kp_lon: 2.0
+      speed_slow: 0.12             # carrot speed when close/turning (m/s)
+      speed_angular: 45.0          # rotation speed for in-place turns (deg/s)
+                                   # Matches OpenMower ftc_local_planner.yaml
+                                   # (45°/s). Previously 60°/s — 33% higher
+                                   # than both OM (45) and mowgli (40), and
+                                   # clipping against max_cmd_vel_ang=1.0 rad/s
+                                   # (60°/s = 1.05 rad/s > cap) → saturation
+                                   # that showed up as erratic tracking.
+      # Carrot acceleration. Was 1.0 m/s² ("higher to overcome grass") which
+      # is 10× the legacy mowgli FTCPlanner (0.1 m/s²) and reaches the 0.20
+      # speed_fast target in 0.2 s instead of 2 s — the operator-visible
+      # "robot lurches forward too fast" symptom. 0.2 m/s² gives a smooth
+      # 1 s ramp without losing grass authority once moving.
+      acceleration: 0.2
+      # PID longitudinal — kp halved to 1.0 (legacy mowgli value). The
+      # previous 2.0 paired with the 1.0 m/s² acceleration produced a
+      # controller that fired hard corrections at every tick.
+      kp_lon: 1.0
       ki_lon: 0.0
       kd_lon: 0.0
-      # PID lateral — kp=2.0 (original). A bump to 3.0 was attempted on
-      # 2026-04-24 post firmware-deadband-fix; in combination with the more
-      # aggressive kp_ang/kd_ang it caused visible oscillation during a
-      # live mow, so reverted to 2.0 (confirmed stable live before stop).
+      # PID lateral — kp=2.0 matches both legacy mowgli and OM. Re-enable
+      # a moderate kd_lat (1.0, vs legacy 5.0) to damp lateral oscillation
+      # caused by GPS-noise-induced position jitter feeding the lateral
+      # error PID. 5.0 (legacy) was too high for our RTK-σ ~3 mm noise
+      # floor and amplified jitter; 1.0 bleeds off overshoot without
+      # turning the derivative into a noise pump.
       kp_lat: 2.0
       ki_lat: 0.0
-      kd_lat: 0.0
-      # PID angular — kp=2.5, kd=0.0 (mild bump from original 2.0). The
-      # 4.0 + kd=0.5 combo tried on 2026-04-24 caused the controller to
-      # amplify GPS-noise-induced yaw measurement jitter, producing
-      # physical vibration during live mow. 2.5 sans kd keeps snappy
-      # tracking without the derivative kick.
-      kp_ang: 2.5
+      kd_lat: 1.0
+      # PID angular — kp=1.5 (between legacy 1.0 and previous 2.5). The 2.5
+      # value combined with kp_lon=2.0 / accel=1.0 was tuned for a stack
+      # that was visually "too fast"; with the slower carrot ramp it can
+      # come back down. kd kept at 0 — derivative on yaw amplified GPS
+      # measurement noise on 2026-04-24.
+      kp_ang: 1.5
       ki_ang: 0.0
       kd_ang: 0.0
       # Limits — cap angular command at 1.0 rad/s (was 3.0). The UKF

--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -570,7 +570,7 @@ collision_monitor:
     cmd_vel_in_topic: cmd_vel_nav
     cmd_vel_out_topic: cmd_vel_safe
     state_topic: collision_monitor_state
-    transform_tolerance: 0.2
+    transform_tolerance: 0.5
     # Source timeout: how long before stale sensor data triggers a stop.
     # ARM boards can have TF/scan timing jitter — 5s avoids false stops
     # while still catching genuinely dead sensors.

--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -535,6 +535,17 @@ docking_server:
     fixed_frame: odom
     dock_backwards: false
     dock_prestaging_tolerance: 0.5
+    # Disable the docking controller's internal collision check. It
+    # projects the dock-approach trajectory through the local_costmap
+    # and aborts if any cell exceeds dock_collision_threshold — but the
+    # dock structure itself shows up in the obstacle layer as soon as
+    # the LiDAR sees it, so the controller refuses its own destination
+    # and DockRobot times out with "Failed to get control / Timed out
+    # resetting dock approach". collision_monitor (downstream of nav2,
+    # always active) still enforces the chassis-polygon emergency stop,
+    # so disabling the docking-internal check doesn't remove safety —
+    # it just stops the docking server from refusing to dock at the dock.
+    controller.use_collision_detection: false
     # Named dock instances — BT uses dock_id="home_dock"
     dock_plugins: ["simple_charging_dock"]
     docks: ["home_dock"]

--- a/ros2/src/mowgli_bringup/launch/kinematic_icp.launch.py
+++ b/ros2/src/mowgli_bringup/launch/kinematic_icp.launch.py
@@ -124,6 +124,8 @@ def generate_launch_description() -> LaunchDescription:
         name="kinematic_icp_online_node",
         namespace="kinematic_icp",
         output="screen",
+        respawn=True,
+        respawn_delay=2.0,
         parameters=[
             kicp_config,
             {

--- a/ros2/src/mowgli_localization/scripts/kinematic_icp_encoder_adapter.py
+++ b/ros2/src/mowgli_localization/scripts/kinematic_icp_encoder_adapter.py
@@ -179,7 +179,18 @@ class KinematicIcpEncoderAdapter(Node):
             var_vx, var_vy, var_wz = self.VAR_VX_BAD, self.VAR_VY_BAD, self.VAR_WZ_BAD
 
         out = Odometry()
+        # Stamp with `now` instead of the K-ICP scan time. K-ICP carries the
+        # original LaserScan timestamp through ICP (~80 ms) + transport into
+        # the adapter (~280 ms more), so msg.header.stamp lands ~350 ms in
+        # the past at the EKF. robot_localization treats that as a delayed
+        # measurement, rewinds its state, replays every newer measurement —
+        # under our 10 Hz K-ICP load this collapsed ekf_odom from 25 Hz
+        # target to a steady 5 Hz publish. The twist we publish is a body-
+        # frame velocity that's approximately constant over the 100 ms
+        # K-ICP cycle, so attributing it to "now" instead of "350 ms ago"
+        # has negligible effect on the fused state.
         out.header = msg.header
+        out.header.stamp = self.get_clock().now().to_msg()
         out.child_frame_id = msg.child_frame_id
         out.pose = msg.pose   # pass pose through (FusionCore ignores it on this topic)
         out.twist.twist.linear.x = vx_body


### PR DESCRIPTION
## Summary

Cherry-picks 6 non-localization upstream commits from \`cedbossneo/main\`. **Excluded:** anything that depends on the upstream EKF migration (FusionCore → robot_localization). That architectural change is a separate workstream on its own branch with field-test gating.

## What's in

| Commit (upstream SHA) | Why we want it |
|---|---|
| \`521e066\` fix(nav2): bump collision_monitor transform_tolerance to 0.5s | Reduces TF-jitter false positives on ARM under load |
| \`b6776d2\` tune(kinematic-icp): permissive correspondence + respawn | Sparse 2D LD19 scans can drop frames during fast yaw → freeze K-ICP for ~1 s; respawn + permissive threshold prevents that |
| \`11cf009\` fix(kinematic-icp): stamp /encoder2/odom with now, not scan time | Was: K-ICP scan timestamp landed ~350 ms in the past at the EKF → \"stale measurement\" handling cost CPU. Now stamped at publish time |
| \`f9cca9f\` fix(bt): report AUTONOMOUS during docking + returning-home flows | Five docking entry points were publishing IDLE before DockRobot — firmware ignores cmd_vel in IDLE → robot just sat there during auto-redock. Switch to AUTONOMOUS so cmd_vel actually reaches motors. **Root cause of the long-standing 'auto-redock broken' behaviour.** |
| \`7e0d6e8\` fix(bt+nav2): unblock auto-redock pipeline | Companion to f9cca9f. Removes spurious BoundaryGuard interference during redock + nav2_params for docking_server tolerances |
| \`4903938\` tune(nav2): soften FTC gains + slower carrot ramp | speed_slow 0.30→0.12 m/s, speed_angular 60°/s→45°/s (was clipping max_cmd_vel_ang), acceleration 1.0→0.2 m/s² (was 10× legacy mowgli — caused \"robot lurches forward\"), kp_lon 2.0→1.0. **Net: smoother strip following** |

## What's NOT in (and why)

- \`1c93578\` perf(localization): touches files we deleted/don't have. Skipped.
- \`16bdccc\` feat(coverage): MBR strip auto-align — 7 conflict regions in our custom strip planner. Will be its own PR + Pi5 mowing-test verify.
- \`668b2fe\` feat(localization): blend wheel + K-ICP — part of the EKF migration. Separate branch.
- Dependabot bumps — managed by our fork's dependabot.

## Conflict resolutions

- \`main_tree.xml\`: 3 conflicts where upstream changes \`state=1\` to \`state=2\` and our HEAD adds \`<SaveSlamMap>\` calls. Kept both.
- \`nav2_params.yaml\`: FTC tuning block — accepted upstream's values (the point of the cherry-pick).
- \`robot_localization.yaml\` deleted (belongs to EKF migration, not this PR).

## Test plan (Pi5)

- [ ] BT auto-redock works end-to-end: COMMAND_HOME → robot drives to dock (was sitting still due to IDLE state)
- [ ] FTC mowing: smoother strip-following, less yaw oscillation, no \"lurch forward\" on coverage start
- [ ] K-ICP doesn't freeze for ~1 s on fast yaw
- [ ] No regression in collision_monitor behavior (transform_tolerance 0.2 → 0.5 s)