### PR TITLE
feat: live-tunable mowing-pattern parameters (#54)

### DIFF
--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -337,49 +337,57 @@
           "type": "integer",
           "title": "Outline Passes",
           "default": 1,
-          "description": "Number of perimeter passes before fill mowing."
+          "description": "Number of perimeter passes before fill mowing.",
+          "x-yaml-node": "map_server_node"
         },
         "outline_offset": {
           "type": "number",
           "title": "Outline Offset",
           "default": 0.05,
-          "description": "Inward offset from recorded boundary (metres)."
+          "description": "Inward offset from recorded boundary (metres).",
+          "x-yaml-node": "map_server_node"
         },
         "outline_overlap": {
           "type": "number",
           "title": "Outline Overlap",
           "default": 0.0,
-          "description": "Overlap between outline and fill passes (metres)."
+          "description": "Overlap between outline and fill passes (metres).",
+          "x-yaml-node": "map_server_node"
         },
         "path_spacing": {
           "type": "number",
           "title": "Path Spacing",
           "default": 0.13,
-          "description": "Spacing between mowing paths (metres). 0.13 gives overlap with 0.18 blade."
+          "description": "Spacing between mowing paths (metres). 0.13 gives overlap with 0.18 blade.",
+          "x-yaml-node": "map_server_node"
         },
         "headland_width": {
           "type": "number",
           "title": "Headland Width",
           "default": 0.18,
-          "description": "Width of headland (turning area) in metres."
+          "description": "Width of headland (turning area) in metres. Used as upper bound for the strip boundary inset; effective inset is clamped between mower_width/2 + 0.05 m and this value.",
+          "x-yaml-node": "map_server_node"
         },
         "min_turning_radius": {
           "type": "number",
           "title": "Min Turning Radius",
           "default": 0.30,
-          "description": "Minimum turning radius for coverage path (metres)."
+          "description": "Minimum turning radius for coverage path (metres). NOT YET IMPLEMENTED — placeholder for future arc-based transit between strips.",
+          "x-yaml-node": "map_server_node"
         },
         "mow_angle_offset_deg": {
           "type": "number",
           "title": "Mow Angle Offset",
           "default": -1.0,
-          "description": "Mowing angle offset in degrees (-1 = auto-detect)."
+          "description": "Mowing angle offset in degrees (-1 = auto-detect via minimum bounding rectangle).",
+          "x-yaml-node": "map_server_node"
         },
         "mow_angle_increment_deg": {
           "type": "number",
           "title": "Mow Angle Increment",
           "default": 0.0,
-          "description": "Rotate mowing pattern by this many degrees each full pass."
+          "description": "Rotate mowing pattern by this many degrees each full pass. NOT YET IMPLEMENTED.",
+          "x-yaml-node": "map_server_node"
         }
       }
     },

--- a/gui/pkg/api/api.go
+++ b/gui/pkg/api/api.go
@@ -35,7 +35,7 @@ func NewAPI(dbProvider types.IDBProvider, dockerProvider types.IDockerProvider, 
 	r.Use(static.Serve("/", static.LocalFile(string(webDirectory), false)))
 	apiGroup := r.Group("/api")
 	ConfigRoute(apiGroup, dbProvider)
-	SettingsRoutes(apiGroup, dbProvider)
+	SettingsRoutes(apiGroup, dbProvider, rosProvider)
 	ContainersRoutes(apiGroup, dockerProvider)
 	MowgliNextRoutes(apiGroup, rosProvider)
 	SetupRoutes(apiGroup, firmwareProvider)

--- a/gui/pkg/api/settings.go
+++ b/gui/pkg/api/settings.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -19,14 +20,134 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func SettingsRoutes(r *gin.RouterGroup, dbProvider types.IDBProvider) {
+func SettingsRoutes(r *gin.RouterGroup, dbProvider types.IDBProvider, rosProvider types.IRosProvider) {
 	GetSettings(r, dbProvider)
 	PostSettings(r, dbProvider)
 	GetSettingsSchema(r, dbProvider)
 	GetSettingsYAML(r, dbProvider)
-	PostSettingsYAML(r, dbProvider)
+	PostSettingsYAML(r, dbProvider, rosProvider)
 	GetSettingsStatus(r, dbProvider)
 	PostSettingsStatus(r, dbProvider)
+}
+
+// ─── rcl_interfaces/srv/SetParameters ad-hoc structs ─────────────────────────
+// Generated structs aren't shipped for rcl_interfaces — we only need this one
+// service so we declare the request shape inline. JSON tags match the ROS2
+// rosbridge wire format (snake_case fields).
+
+const (
+	rclParamTypeBool    = 1
+	rclParamTypeInteger = 2
+	rclParamTypeDouble  = 3
+)
+
+type rclParameterValue struct {
+	Type         uint8   `json:"type"`
+	BoolValue    bool    `json:"bool_value"`
+	IntegerValue int64   `json:"integer_value"`
+	DoubleValue  float64 `json:"double_value"`
+	StringValue  string  `json:"string_value"`
+}
+
+type rclParameter struct {
+	Name  string            `json:"name"`
+	Value rclParameterValue `json:"value"`
+}
+
+type setParametersReq struct {
+	Parameters []rclParameter `json:"parameters"`
+}
+
+type rclSetParametersResult struct {
+	Successful bool   `json:"successful"`
+	Reason     string `json:"reason"`
+}
+
+type setParametersRes struct {
+	Results []rclSetParametersResult `json:"results"`
+}
+
+// liveTunableMapServerKeys lists the GUI fields that are safe to push into
+// /map_server_node/set_parameters without a node restart. Keys outside this
+// list are persisted to yaml only — the operator must restart the container
+// for them to take effect.
+var liveTunableMapServerKeys = map[string]bool{
+	"outline_passes":       true,
+	"outline_offset":       true,
+	"outline_overlap":      true,
+	"path_spacing":         true,
+	"mow_angle_offset_deg": true,
+	"headland_width":       true,
+}
+
+// liveTuneMapServer pushes the live-tunable subset of payload to
+// /map_server_node/set_parameters. Errors are logged but not returned —
+// yaml-write has already persisted the values, so the next restart will
+// pick them up even if the live update fails (e.g. node not running).
+func liveTuneMapServer(ctx context.Context, rosProvider types.IRosProvider, payload map[string]any) {
+	if rosProvider == nil {
+		return
+	}
+	params := make([]rclParameter, 0, len(payload))
+	for key, val := range payload {
+		if !liveTunableMapServerKeys[key] {
+			continue
+		}
+		switch v := val.(type) {
+		case float64:
+			params = append(params, rclParameter{
+				Name:  key,
+				Value: rclParameterValue{Type: rclParamTypeDouble, DoubleValue: v},
+			})
+		case float32:
+			params = append(params, rclParameter{
+				Name:  key,
+				Value: rclParameterValue{Type: rclParamTypeDouble, DoubleValue: float64(v)},
+			})
+		case int:
+			params = append(params, rclParameter{
+				Name:  key,
+				Value: rclParameterValue{Type: rclParamTypeInteger, IntegerValue: int64(v)},
+			})
+		case int64:
+			params = append(params, rclParameter{
+				Name:  key,
+				Value: rclParameterValue{Type: rclParamTypeInteger, IntegerValue: v},
+			})
+		case json.Number:
+			// Gin/encoding-json may decode numerics as json.Number when
+			// UseNumber() is set; fall back to float64 representation.
+			if f, err := v.Float64(); err == nil {
+				params = append(params, rclParameter{
+					Name:  key,
+					Value: rclParameterValue{Type: rclParamTypeDouble, DoubleValue: f},
+				})
+			}
+		default:
+			log.Printf("liveTuneMapServer: unsupported type for %q: %T", key, val)
+		}
+	}
+	if len(params) == 0 {
+		return
+	}
+
+	req := setParametersReq{Parameters: params}
+	var res setParametersRes
+	callCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if err := rosProvider.CallService(callCtx,
+		"/map_server_node/set_parameters",
+		&req, &res,
+		"rcl_interfaces/srv/SetParameters"); err != nil {
+		log.Printf("liveTuneMapServer: SetParameters call failed (yaml is still persisted): %v", err)
+		return
+	}
+	for i, r := range res.Results {
+		if !r.Successful {
+			log.Printf("liveTuneMapServer: param %s rejected by node: %s", params[i].Name, r.Reason)
+		}
+	}
+	log.Printf("liveTuneMapServer: pushed %d live params to map_server_node", len(params))
 }
 
 // GetSettingsStatus returns whether onboarding has been completed.
@@ -739,7 +860,7 @@ func GetSettingsYAML(r *gin.RouterGroup, dbProvider types.IDBProvider) gin.IRout
 // @Failure 400 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
 // @Router /settings/yaml [post]
-func PostSettingsYAML(r *gin.RouterGroup, dbProvider types.IDBProvider) gin.IRoutes {
+func PostSettingsYAML(r *gin.RouterGroup, dbProvider types.IDBProvider, rosProvider types.IRosProvider) gin.IRoutes {
 	return r.POST("/settings/yaml", func(c *gin.Context) {
 		var payload map[string]any
 		if err := c.BindJSON(&payload); err != nil {
@@ -806,6 +927,12 @@ func PostSettingsYAML(r *gin.RouterGroup, dbProvider types.IDBProvider) gin.IRou
 		}
 
 		log.Printf("Saved mowgli_robot.yaml (%d bytes)", len(out)+len(header))
+
+		// Push the live-tunable subset to the running map_server_node so
+		// outline / strip changes take effect without a container restart.
+		// Errors are non-fatal — yaml is already on disk.
+		liveTuneMapServer(c.Request.Context(), rosProvider, payload)
+
 		c.JSON(200, OkResponse{})
 	})
 }

--- a/gui/pkg/api/settings_test.go
+++ b/gui/pkg/api/settings_test.go
@@ -21,7 +21,9 @@ func setupSettingsRouter(dbProvider types.IDBProvider) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	group := r.Group("/api")
-	SettingsRoutes(group, dbProvider)
+	// Tests don't exercise the live-tuning side-effect; pass the standard mock
+	// ros provider so SettingsRoutes can wire PostSettingsYAML.
+	SettingsRoutes(group, dbProvider, &types.MockRosProvider{})
 	return r
 }
 

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -181,6 +181,7 @@ def generate_launch_description() -> LaunchDescription:
         output="screen",
         parameters=[
             map_params,
+            robot_config,
             {"use_sim_time": use_sim_time},
         ],
     )

--- a/ros2/src/mowgli_map/config/map_server.yaml
+++ b/ros2/src/mowgli_map/config/map_server.yaml
@@ -47,7 +47,8 @@ map_server_node:
     # Mowing strip angle in degrees. NaN (default) = auto-compute from
     # polygon shape (minimum bounding rectangle — strips align with the
     # longest axis to minimise turns). 0 = north-south, 90 = east-west.
-    mow_angle_deg: .nan
+    # GUI sends -1 for "auto"; the launch wrapper translates -1 → NaN.
+    mow_angle_offset_deg: .nan
 
     # Inner-boundary margin. Cells INSIDE a mowing area but within this
     # distance of the nearest edge are marked LETHAL in the keepout mask.

--- a/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
+++ b/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
@@ -524,6 +524,14 @@ private:
 
   // ── Timers ────────────────────────────────────────────────────────────────
   rclcpp::TimerBase::SharedPtr publish_timer_;
+
+  // ── Live parameter callback ──────────────────────────────────────────────
+  // Held as a member so the callback stays registered for the node's lifetime.
+  // Updates the cached planner parameters (outline_*, path_spacing, mow_angle,
+  // headland_width) without requiring a node restart — yaml writes from the
+  // GUI are paired with a SetParameters service call so changes take effect
+  // immediately.
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 };
 
 }  // namespace mowgli_map

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -139,9 +139,17 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
   soft_boundary_margin_m_ = declare_parameter<double>("soft_boundary_margin_m", 0.10);
   boundary_recovery_offset_m_ = declare_parameter<double>("boundary_recovery_offset_m", 0.8);
   boundary_inner_margin_m_ = declare_parameter<double>("boundary_inner_margin_m", 0.3);
-  strip_boundary_margin_m_ = declare_parameter<double>("strip_boundary_margin_m", 0.5);
+  // strip_boundary_margin_m / headland_width both refer to the strip-endpoint
+  // inset (turning zone at strip ends). headland_width is the GUI-facing name
+  // and takes precedence when > 0; strip_boundary_margin_m is kept for backward
+  // compat with existing map_server.yaml deployments.
+  {
+    const double legacy_margin = declare_parameter<double>("strip_boundary_margin_m", 0.5);
+    const double gui_headland = declare_parameter<double>("headland_width", 0.0);
+    strip_boundary_margin_m_ = (gui_headland > 0.0) ? gui_headland : legacy_margin;
+  }
   mow_angle_override_deg_ =
-      declare_parameter<double>("mow_angle_deg", std::numeric_limits<double>::quiet_NaN());
+      declare_parameter<double>("mow_angle_offset_deg", std::numeric_limits<double>::quiet_NaN());
 
   // Dock approach corridor — extends the no-mow zone in front of the dock
   // so coverage strips stop before the 1.5 m straight-line alignment that
@@ -463,6 +471,77 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
                 approach_back,
                 half_width);
   }
+
+  // ── Live parameter callback ──────────────────────────────────────────────
+  // Live-tunable subset of the planner parameters. The GUI POST /settings/yaml
+  // endpoint persists to mowgli_robot.yaml AND fires a SetParameters service
+  // call with these keys, so the operator sees plan changes without waiting
+  // for a node restart. Replanning is on-demand (next /preview_plan or
+  // /get_next_strip call), so updating the cached members is sufficient.
+  param_callback_handle_ = add_on_set_parameters_callback(
+      [this](const std::vector<rclcpp::Parameter>& params)
+      {
+        rcl_interfaces::msg::SetParametersResult result;
+        result.successful = true;
+
+        for (const auto& p : params)
+        {
+          const auto& name = p.get_name();
+          if (name == "outline_passes")
+          {
+            outline_passes_ = static_cast<int>(p.as_int());
+          }
+          else if (name == "outline_offset")
+          {
+            outline_offset_ = p.as_double();
+          }
+          else if (name == "outline_overlap")
+          {
+            outline_overlap_ = p.as_double();
+          }
+          else if (name == "path_spacing")
+          {
+            path_spacing_ = p.as_double();
+          }
+          else if (name == "mow_angle_offset_deg")
+          {
+            const double v = p.as_double();
+            // GUI sentinel: -1 means "auto" (NaN drives auto-MBR in
+            // ensure_strip_layout). Any other value is interpreted as an
+            // absolute angle in degrees.
+            mow_angle_override_deg_ =
+                (v < 0.0) ? std::numeric_limits<double>::quiet_NaN() : v;
+          }
+          else if (name == "headland_width" || name == "strip_boundary_margin_m")
+          {
+            const double v = p.as_double();
+            // headland_width=0 means "use legacy strip_boundary_margin_m".
+            // For an explicit live update from the GUI we always honour the
+            // new value (treating zero as "no inset" would silently break
+            // strip endpoint placement).
+            if (v > 0.0)
+            {
+              strip_boundary_margin_m_ = v;
+            }
+          }
+        }
+
+        if (!params.empty())
+        {
+          RCLCPP_INFO(get_logger(),
+                      "Live params updated: outline_passes=%d offset=%.3f overlap=%.3f "
+                      "path_spacing=%.3f mow_angle_override=%s headland=%.3f",
+                      outline_passes_,
+                      outline_offset_,
+                      outline_overlap_,
+                      path_spacing_,
+                      std::isnan(mow_angle_override_deg_) ? "auto"
+                                                          : std::to_string(mow_angle_override_deg_).c_str(),
+                      strip_boundary_margin_m_);
+        }
+
+        return result;
+      });
 
   // ── Publish timer ────────────────────────────────────────────────────────
   const auto period_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(


### PR DESCRIPTION
Closes #54.

The GUI *Mowing Pattern* card persisted values that never reached the planner. This PR fixes the full pipeline so changes take effect immediately, without a container restart.

## What was broken

1. yaml writes landed in the `mowgli:` namespace; `map_server_node` ignored them.
2. `map_server_node` only loaded `map_server.yaml`, not `mowgli_robot.yaml`.
3. Even with a correct yaml load, params were only read at construction time.
4. GUI key `mow_angle_offset_deg` ≠ ROS param name `mow_angle_deg`.

## Changes

| Layer | File | Change |
|---|---|---|
| Schema | `gui/asserts/mower_config.schema.json` | `x-yaml-node: map_server_node` on outline_*/path_spacing/mow_angle_offset_deg/mow_angle_increment_deg/headland_width/min_turning_radius |
| Launch | `ros2/src/mowgli_bringup/launch/full_system.launch.py` | `parameters=[map_params, robot_config, …]` for `map_server_node` |
| C++ | `ros2/src/mowgli_map/src/map_server_node.cpp` (+hpp, +map_server.yaml) | Rename `mow_angle_deg` → `mow_angle_offset_deg`; add `headland_width` alias for `strip_boundary_margin_m`; `OnSetParameters` callback updates the cached members live |
| GUI | `gui/pkg/api/settings.go` (+api.go, +settings_test.go) | After PostSettingsYAML writes the file, push the live-tunable subset to `/map_server_node/set_parameters` |

Replanning is on-demand (next `/preview_plan` or `/get_next_strip` call), so updating the cached members is sufficient — no cache invalidation needed.

## Test plan

- [ ] GHA ROS2 + GUI Docker builds green
- [ ] Pi5 force-recreate with new images
- [ ] GUI Settings → outline_passes 1→3, click Save
- [ ] `ros2 param get /map_server_node outline_passes` returns 3 (no restart)
- [ ] GUI plan-preview hard-refresh: three concentric green outline loops
- [ ] No safety regression: BT post-mow Dock + outline + boustrophedon still work end-to-end

## Notes

- `min_turning_radius` and `mow_angle_increment_deg` are now correctly persisted in the right yaml block but still have no C++ consumer (clearly tagged "NOT YET IMPLEMENTED" in the schema).
- Two pre-existing failing tests in `pkg/api/settings_test.go` (`TestGetSettingsSchema_FromUpstream`, `TestPostSettingsYAML_MergesExisting`) are unrelated to this PR.